### PR TITLE
feat: Add graphical form to edit language semantics with toggle for textual mode

### DIFF
--- a/src/core/components/LanguageDetail/Semantics/AttributeRuleModal.tsx
+++ b/src/core/components/LanguageDetail/Semantics/AttributeRuleModal.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import { Form, Button, Modal, ListGroup } from 'react-bootstrap';
+
+interface AttributeTranslationRule {
+    parent: string;
+    param: string;
+    template: string;
+    constraint: string;
+}
+
+interface AttributeTranslationRuleModalProps {
+    show: boolean;
+    elementName: string;
+    properties: string[];
+    rule?: Record<string, AttributeTranslationRule>[];
+    onSave: (propertyName: string, updatedRule: AttributeTranslationRule) => void;
+    onClose: () => void;
+}
+
+export default function AttributeRuleModal({
+    show,
+    elementName,
+    properties,
+    rule,
+    onSave,
+    onClose
+}: AttributeTranslationRuleModalProps) {
+    const [selectedProperty, setSelectedProperty] = useState<string | null>(null);
+    const [localRule, setLocalRule] = useState<AttributeTranslationRule>({
+        parent: '',
+        param: '',
+        template: '',
+        constraint: ''
+    });
+
+    // Estado para controlar la etapa del modal
+    const [modalStage, setModalStage] = useState<'propertySelection' | 'ruleEdition'>('propertySelection');
+
+    useEffect(() => {
+        // Reiniciar estados cuando se abre el modal
+        if (show) {
+            setSelectedProperty(null);
+            setModalStage('propertySelection');
+            setLocalRule({
+                parent: '',
+                param: '',
+                template: '',
+                constraint: ''
+            });
+        }
+    }, [show]);
+
+    // useEffect(() => {
+    //     // Si hay una regla existente, cargarla
+    //     if (rule) {
+    //         setLocalRule(rule);
+    //     }
+    // }, [rule]);
+
+    const handlePropertySelection = (property: string) => {
+        setSelectedProperty(property);
+        if (rule[property]) {
+            setLocalRule(rule[property]);
+        }
+        setModalStage('ruleEdition');
+    };
+
+    const handleSave = () => {
+        if (selectedProperty) {
+            onSave(selectedProperty, localRule);
+            onClose();
+        }
+    };
+
+    const renderPropertySelection = () => (
+        <Modal.Body>
+            <h5>Select a Property for {elementName}</h5>
+            <ListGroup>
+                {properties.map(property => (
+                    <ListGroup.Item 
+                        key={property} 
+                        action 
+                        onClick={() => handlePropertySelection(property)}
+                    >
+                        {property}
+                    </ListGroup.Item>
+                ))}
+            </ListGroup>
+        </Modal.Body>
+    );
+
+    const renderRuleEdition = () => (
+        <Modal.Body>
+            <Form>
+                <Form.Group className="mb-3">
+                    <Form.Label>Selected Property: {selectedProperty}</Form.Label>
+                </Form.Group>
+                <Form.Group className="mb-3">
+                    <Form.Label>Parent</Form.Label>
+                    <Form.Control
+                        type="text"
+                        value={localRule.parent}
+                        onChange={(e) => setLocalRule({ ...localRule, parent: e.target.value })}
+                        placeholder="Enter parent identifier"
+                    />
+                </Form.Group>
+                <Form.Group className="mb-3">
+                    <Form.Label>Param</Form.Label>
+                    <Form.Control
+                        type="text"
+                        value={localRule.param}
+                        onChange={(e) => setLocalRule({ ...localRule, param: e.target.value })}
+                        placeholder="Enter parameter name"
+                    />
+                </Form.Group>
+                <Form.Group className="mb-3">
+                    <Form.Label>Template</Form.Label>
+                    <Form.Control
+                        type="text"
+                        value={localRule.template}
+                        onChange={(e) => setLocalRule({ ...localRule, template: e.target.value })}
+                        placeholder="Enter template"
+                    />
+                </Form.Group>
+                <Form.Group>
+                    <Form.Label>Constraint</Form.Label>
+                    <Form.Control
+                        as="textarea"
+                        value={localRule.constraint}
+                        onChange={(e) => setLocalRule({ ...localRule, constraint: e.target.value })}
+                        placeholder="Enter constraint logic"
+                    />
+                </Form.Group>
+            </Form>
+        </Modal.Body>
+    );
+
+    return (
+        <Modal show={show} onHide={onClose} size="lg">
+            <Modal.Header closeButton>
+                <Modal.Title>
+                    {modalStage === 'propertySelection' 
+                        ? `Select Property for ${elementName}` 
+                        : `Edit Attribute Translation Rule for ${selectedProperty}`
+                    }
+                </Modal.Title>
+            </Modal.Header>
+            
+            {modalStage === 'propertySelection' 
+                ? renderPropertySelection() 
+                : renderRuleEdition()}
+            
+            <Modal.Footer>
+                {modalStage === 'propertySelection' ? (
+                    <Button variant="secondary" onClick={onClose}>Cancel</Button>
+                ) : (
+                    <>
+                        <Button 
+                            variant="secondary" 
+                            onClick={() => setModalStage('propertySelection')}
+                        >
+                            Back to Properties
+                        </Button>
+                        <Button variant="primary" onClick={handleSave}>
+                            Apply Rule
+                        </Button>
+                    </>
+                )}
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/core/components/LanguageDetail/Semantics/PropertySchemaModal.tsx
+++ b/src/core/components/LanguageDetail/Semantics/PropertySchemaModal.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { Form, Button, Modal } from 'react-bootstrap';
+
+interface PropertySchema {
+    type: {
+        index: number;
+        key: string;
+    }
+}
+
+interface PropertySchemaModalProps {
+    show: boolean;
+    schema: PropertySchema | null;
+    onSave: (updatedSchema: PropertySchema) => void;
+    onClose: () => void;
+}
+
+export default function PropertySchemaModal({
+    show,
+    schema,
+    onSave,
+    onClose
+}: PropertySchemaModalProps ) {
+
+    const [localSchema, setLocalSchema] = useState<PropertySchema>({
+        type: {
+            index: schema?.type?.index ?? 0,
+            key: schema?.type?.key ?? ''
+        }
+    });
+
+    useEffect(() => {
+        if (schema) {
+            setLocalSchema({
+                type: {
+                    index: schema.type?.index ?? 0,
+                    key: schema.type?.key ?? ''
+                }
+            });
+        }
+    }, [schema]);
+
+    const handleSave = () => {
+        if (localSchema.type) {
+            onSave(localSchema);
+        }
+    };
+
+    return (
+        <Modal show={show} onHide={onClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>Edit Property Schema</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Form.Group>
+                        <Form.Label>Index</Form.Label>
+                        <input
+                            type="number"
+                            value={localSchema.type.index}
+                            onChange={(e) => setLocalSchema({ ...localSchema, type: { ...localSchema.type, index: parseInt(e.target.value)} })}
+                            style={{ width: '50px', textAlign: 'center' }}
+                            className="mx-2"
+                        />
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label>Key</Form.Label>
+                        <Form.Control
+                            type="text"
+                            value={localSchema.type.key}
+                            onChange={(e) => setLocalSchema({ ...localSchema, type: { ...localSchema.type, key: e.target.value } })}
+                        />
+                    </Form.Group>
+                </Form>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="primary" onClick={handleSave}>Save</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+
+};

--- a/src/core/components/LanguageDetail/Semantics/RelationReificationTranslationRule.tsx
+++ b/src/core/components/LanguageDetail/Semantics/RelationReificationTranslationRule.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from "react";
+import { Form, Button, Modal, Row, Col } from 'react-bootstrap';
+import { BiTrash, BiPlus } from "react-icons/bi";
+
+interface RelationReificationTranslationRule {
+    param: string[];
+    paramMapping: {
+        inboundEdges: {
+            unique: boolean;
+            var: string;
+        };
+        outboundEdges: {
+            unique: boolean;
+            var: string;
+        };
+    };
+    constraint: {
+        [key: string]: string;
+    };
+}
+
+interface RelationReificationTranslationRuleModalProps {
+    show: boolean;
+    relationReificationType: string;
+    rule: RelationReificationTranslationRule;
+    onSave: (updatedRule: RelationReificationTranslationRule) => void;
+    onClose: () => void;
+}
+
+export default function RelationReificationTranslationRuleModal({
+    show,
+    relationReificationType,
+    rule,
+    onSave,
+    onClose
+}: RelationReificationTranslationRuleModalProps) {
+    const [localRule, setLocalRule] = useState<RelationReificationTranslationRule>(rule);
+
+    const [newConstraintKey, setNewConstraintKey] = useState('');
+    const [newConstraintValue, setNewConstraintValue] = useState('');
+
+    useEffect(() => {
+        setLocalRule(rule);
+    }, [rule]);
+
+    const updateParam = (index: number, value: string) => {
+        const newParams = [...localRule.param];
+        newParams[index] = value;
+        setLocalRule({ ...localRule, param: newParams });
+    };
+
+    const addParam = () => {
+        setLocalRule({ 
+            ...localRule, 
+            param: [...localRule.param, ''] 
+        });
+    };
+
+    const removeParam = (index: number) => {
+        const newParams = localRule.param.filter((_, i) => i !== index);
+        setLocalRule({ ...localRule, param: newParams });
+    };
+
+    const updateConstraint = (key: string, value: string) => {
+        setLocalRule({ 
+            ...localRule, 
+            constraint: { 
+                ...localRule.constraint, 
+                [key]: value 
+            } 
+        });
+    };
+
+    const addConstraint = () => {
+        const newKey = newConstraintKey.trim();
+        const newValue = newConstraintValue.trim();
+
+        if (newKey && newValue) {
+            setLocalRule({ 
+                ...localRule, 
+                constraint: { 
+                    ...localRule.constraint, 
+                    [newKey]: newValue 
+                } 
+            });
+
+            setNewConstraintKey('');
+            setNewConstraintValue('');
+        }
+    };
+
+    const removeConstraint = (key: string) => {
+        const newConstraints = { ...localRule.constraint };
+        delete newConstraints[key];
+        setLocalRule({ ...localRule, constraint: newConstraints });
+    };
+
+    const handleSave = () => {
+        let finalRule = { ...localRule };
+
+        if (newConstraintKey.trim() && newConstraintValue.trim()) {
+            finalRule = {
+                ...finalRule,
+                constraint: {
+                    ...finalRule.constraint,
+                    [newConstraintKey.trim()]: newConstraintValue.trim()
+                }
+            };
+        }
+
+        onSave(finalRule);
+
+        setNewConstraintKey('');
+        setNewConstraintValue('');
+    };
+
+    return (
+        <Modal show={show} onHide={onClose} size="lg">
+            <Modal.Header closeButton>
+                <Modal.Title>Edit Relation Reification Translation Rules for {relationReificationType}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    {/* Parameters Section */}
+                    <Form.Group className="mb-3">
+                        <Form.Label>Parameters</Form.Label>
+                        {localRule.param.map((param, index) => (
+                            <Row key={index} className="mb-2 align-items-center">
+                                <Col>
+                                    <Form.Control
+                                        type="text"
+                                        placeholder={`Parameter ${index + 1}`}
+                                        value={param}
+                                        onChange={(e) => updateParam(index, e.target.value)}
+                                    />
+                                </Col>
+                                <Col xs="auto">
+                                    <Button 
+                                        variant="outline-danger" 
+                                        size="sm" 
+                                        onClick={() => removeParam(index)}
+                                    >
+                                        <BiTrash />
+                                    </Button>
+                                </Col>
+                            </Row>
+                        ))}
+                        <Button 
+                            variant="outline-primary" 
+                            size="sm" 
+                            onClick={addParam}
+                        >
+                            <BiPlus /> Add Parameter
+                        </Button>
+                    </Form.Group>
+
+                    {/* Parameter Mapping Section */}
+                    <Form.Group className="mb-3">
+                        <Form.Label>Inbound Edges Mapping</Form.Label>
+                        <Row>
+                            <Col>
+                                <Form.Check 
+                                    type="checkbox"
+                                    label="Unique"
+                                    checked={localRule.paramMapping.inboundEdges.unique}
+                                    onChange={(e) => setLocalRule({
+                                        ...localRule,
+                                        paramMapping: {
+                                            ...localRule.paramMapping,
+                                            inboundEdges: {
+                                                ...localRule.paramMapping.inboundEdges,
+                                                unique: e.target.checked
+                                            }
+                                        }
+                                    })}
+                                />
+                            </Col>
+                            <Col>
+                                <Form.Control
+                                    type="text"
+                                    placeholder="Variable Name"
+                                    value={localRule.paramMapping.inboundEdges.var}
+                                    onChange={(e) => setLocalRule({
+                                        ...localRule,
+                                        paramMapping: {
+                                            ...localRule.paramMapping,
+                                            inboundEdges: {
+                                                ...localRule.paramMapping.inboundEdges,
+                                                var: e.target.value
+                                            }
+                                        }
+                                    })}
+                                />
+                            </Col>
+                        </Row>
+                    </Form.Group>
+
+                    <Form.Group className="mb-3">
+                        <Form.Label>Outbound Edges Mapping</Form.Label>
+                        <Row>
+                            <Col>
+                                <Form.Check 
+                                    type="checkbox"
+                                    label="Unique"
+                                    checked={localRule.paramMapping.outboundEdges.unique}
+                                    onChange={(e) => setLocalRule({
+                                        ...localRule,
+                                        paramMapping: {
+                                            ...localRule.paramMapping,
+                                            outboundEdges: {
+                                                ...localRule.paramMapping.outboundEdges,
+                                                unique: e.target.checked
+                                            }
+                                        }
+                                    })}
+                                />
+                            </Col>
+                            <Col>
+                                <Form.Control
+                                    type="text"
+                                    placeholder="Variable Name"
+                                    value={localRule.paramMapping.outboundEdges.var}
+                                    onChange={(e) => setLocalRule({
+                                        ...localRule,
+                                        paramMapping: {
+                                            ...localRule.paramMapping,
+                                            outboundEdges: {
+                                                ...localRule.paramMapping.outboundEdges,
+                                                var: e.target.value
+                                            }
+                                        }
+                                    })}
+                                />
+                            </Col>
+                        </Row>
+                    </Form.Group>
+
+                    {/* Constraints Section */}
+                    <Form.Group>
+                        <Form.Label>Constraints</Form.Label>
+                        {Object.entries(localRule.constraint).map(([key, value]) => (
+                            <Row key={key} className="mb-2 align-items-center">
+                                <Col>
+                                    <Form.Control
+                                        type="text"
+                                        value={key}
+                                        readOnly
+                                    />
+                                </Col>
+                                <Col>
+                                    <Form.Control
+                                        as="textarea"
+                                        placeholder="Constraint formula"
+                                        value={value}
+                                        onChange={(e) => updateConstraint(key, e.target.value)}
+                                    />
+                                </Col>
+                                <Col xs="auto">
+                                    <Button 
+                                        variant="outline-danger" 
+                                        size="sm" 
+                                        onClick={() => removeConstraint(key)}
+                                    >
+                                        <BiTrash />
+                                    </Button>
+                                </Col>
+                            </Row>
+                        ))}
+
+                        {/* New row added at the end */}
+                        <Row className="mt-3">
+                            <Col>
+                                <Form.Control
+                                    type="text"
+                                    placeholder="Constraint Name"
+                                    value={newConstraintKey}
+                                    onChange={(e) => setNewConstraintKey(e.target.value)}
+                                />
+                            </Col>
+                            <Col>
+                                <Form.Control
+                                    as="textarea"
+                                    placeholder="Constraint Formula"
+                                    value={newConstraintValue}
+                                    onChange={(e) => setNewConstraintValue(e.target.value)}
+                                />
+                            </Col>
+                            <Col xs="auto" className="d-flex align-items-end">
+                                <Button 
+                                    variant="outline-primary" 
+                                    onClick={addConstraint}
+                                    disabled={!newConstraintKey.trim() || !newConstraintValue.trim()}
+                                >
+                                    <BiPlus /> Add Constraint
+                                </Button>
+                            </Col>
+                        </Row>
+                    </Form.Group>
+
+                </Form>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={onClose}>Cancel</Button>
+                <Button variant="primary" onClick={handleSave}>Apply</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/core/components/LanguageDetail/Semantics/RelationTranslationRule.tsx
+++ b/src/core/components/LanguageDetail/Semantics/RelationTranslationRule.tsx
@@ -1,0 +1,104 @@
+import { useState, useEffect } from 'react';
+import { Modal, Button, Form, Row, Col } from 'react-bootstrap';
+import MultiValueForm from '../GraphicalMode/Utils/FormUtils/MultiValueForm';
+
+interface RelationTranslationRule {
+    params: string[];
+    constraint: string;
+}
+
+interface RelationTranslationRuleModalProps {
+    show: boolean;
+    relationName: string;
+    rule: RelationTranslationRule;
+    selectedElements: string[];
+    onSave: (relationName: string, rule: RelationTranslationRule) => void;
+    onClose: () => void;
+}
+
+export default function RelationTranslationRuleModal({
+    show,
+    relationName,
+    rule,
+    selectedElements,
+    onSave,
+    onClose
+}: RelationTranslationRuleModalProps) {
+
+    const [localRule, setLocalRule] = useState<RelationTranslationRule>({
+        params: [],
+        constraint: ''
+    });
+
+    // Actualizar el estado local cuando cambia la regla externa
+    useEffect(() => {
+        setLocalRule(rule);
+    }, [rule]);
+
+    const handleConstraintChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setLocalRule(prev => ({
+            ...prev,
+            constraint: event.target.value
+        }));
+    };
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        onSave(relationName, localRule);
+    };
+
+    return (
+        <Modal show={show} onHide={onClose} size="lg">
+            <Form onSubmit={handleSubmit}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Translation Rule for Relation: {relationName}</Modal.Title>
+                </Modal.Header>
+                
+                <Modal.Body>
+                    <Form.Group as={Row} className="mb-3">
+                        <Form.Label column sm={3}>Parameters</Form.Label>
+                        <Col sm={9}>
+                            <MultiValueForm
+                                selectedItems={localRule.params || []}
+                                setSelectedItems={params => setLocalRule(prev => ({ ...prev, params }))}
+                            />
+                            <Form.Text className="text-muted">
+                                Select the elements that will be used as parameters in the constraint
+                            </Form.Text>
+                        </Col>
+                    </Form.Group>
+
+                    <Form.Group as={Row} className="mb-3">
+                        <Form.Label column sm={3}>Constraint</Form.Label>
+                        <Col sm={9}>
+                            <Form.Control
+                                as="textarea"
+                                rows={4}
+                                value={localRule.constraint}
+                                onChange={handleConstraintChange}
+                                placeholder="Enter the constraint expression..."
+                            />
+                            <Form.Text className="text-muted">
+                                Define the constraint using the selected parameters. 
+                                Use parameter names directly in the expression.
+                            </Form.Text>
+                        </Col>
+                    </Form.Group>
+                </Modal.Body>
+
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button 
+                        variant="primary" 
+                        type="submit"
+                        disabled={localRule.params.length === 0 || !localRule.constraint.trim()}
+                    >
+                        Save Rule
+                    </Button>
+                </Modal.Footer>
+            </Form>
+        </Modal>
+    );
+}

--- a/src/core/components/LanguageDetail/Semantics/TranslationRule.tsx
+++ b/src/core/components/LanguageDetail/Semantics/TranslationRule.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { Form, Button, Modal } from 'react-bootstrap';
+
+interface TranslationRule {
+    param: string;
+    constraint: string;
+    selectedConstraint: string;
+    deselectedConstraint: string;
+}
+
+interface TranslationRuleModalProps {
+    show: boolean;
+    elementName: string;
+    rule: TranslationRule;
+    onSave: (updatedRule: TranslationRule) => void;
+    onClose: () => void;
+}
+
+// Modal para editar las propiedades de un elemento
+export default function TranslationRuleModal({
+    show,
+    elementName,
+    rule,
+    onSave,
+    onClose
+}: TranslationRuleModalProps ) {
+
+    const [localRule, setLocalRule] = useState<TranslationRule>(rule);
+
+    useEffect(() => {
+        setLocalRule(rule);
+    }, [rule]);
+
+    return (
+        <Modal show={show} onHide={onClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>Edit Translation Rules for {elementName}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Form.Group>
+                        <Form.Label>Param</Form.Label>
+                        <Form.Control
+                            type="text"
+                            value={localRule.param}
+                            onChange={(e) => setLocalRule({ ...localRule, param: e.target.value })}
+                        />
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label>Constraint</Form.Label>
+                        <Form.Control
+                            as="textarea"
+                            value={localRule.constraint}
+                            onChange={(e) => setLocalRule({ ...localRule, constraint: e.target.value })}
+                        />
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label>Selected Constraint</Form.Label>
+                        <Form.Control
+                            as="textarea"
+                            value={localRule.selectedConstraint}
+                            onChange={(e) => setLocalRule({ ...localRule, selectedConstraint: e.target.value })}
+                        />
+                    </Form.Group>
+                    <Form.Group>
+                        <Form.Label>Deselected Constraint</Form.Label>
+                        <Form.Control
+                            as="textarea"
+                            value={localRule.deselectedConstraint}
+                            onChange={(e) => setLocalRule({ ...localRule, deselectedConstraint: e.target.value })}
+                        />
+                    </Form.Group>
+                </Form>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={onClose}>Cancel</Button>
+                <Button variant="primary" onClick={() => onSave(localRule)}>Apply</Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -198,6 +198,7 @@ export default function VisualSemanticEditor({
                         </Col>
                     </Form.Group>
                 )}
+
             </Form>
 
             {selectedRuleElement && (

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -3,6 +3,7 @@ import { Form, Col, Row, Button } from 'react-bootstrap';
 import Select, { MultiValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import TranslationRuleModal from './TranslationRule';
+import RelationTranslationRuleModal from './RelationTranslationRule';
 
 // Interfaces
 interface TranslationRule {
@@ -10,6 +11,11 @@ interface TranslationRule {
     constraint: string;
     selectedConstraint: string;
     deselectedConstraint: string;
+}
+
+interface RelationTranslationRule {
+    params: string[];
+    constraint: string;
 }
 
 interface Element {
@@ -27,11 +33,13 @@ interface VisualSemanticEditorProps {
     selectedElements: string[];
     elementTranslationRules: Record<string, TranslationRule>;
     relationTypes: string[];
+    relationTranslationRules: Record<string, RelationTranslationRule>;
     
     // Event handlers
     onElementsChange: (elements: string[]) => void;
     onTranslationRuleChange: (elementName: string, rule: TranslationRule) => void;
     onRelationsChange: (relations: string[]) => void;
+    onRelationTranslationRuleChange: (relationName: string, rule: RelationTranslationRule) => void;
 }
 
 export default function VisualSemanticEditor({
@@ -39,13 +47,18 @@ export default function VisualSemanticEditor({
     selectedElements,
     elementTranslationRules,
     relationTypes,
+    relationTranslationRules,
     onElementsChange,
     onTranslationRuleChange,
-    onRelationsChange
+    onRelationsChange,
+    onRelationTranslationRuleChange,
 }: VisualSemanticEditorProps) {
 
     const [selectedRuleElement, setSelectedRuleElement] = useState<string | null>(null);
     const [showModal, setShowModal] = useState(false);
+
+    const [selectedRuleRelation, setSelectedRuleRelation] = useState<string | null>(null);
+    const [showRelationModal, setShowRelationModal] = useState(false);
 
     // Efecto para actualizar el modal cuando cambian las reglas
     useEffect(() => {
@@ -55,7 +68,14 @@ export default function VisualSemanticEditor({
                 // Actualizar el estado del modal
             }
         }
-    }, [elementTranslationRules, selectedRuleElement, showModal]);
+
+        if (selectedRuleRelation && showRelationModal) {
+            const currentRule = relationTranslationRules[selectedRuleRelation];
+            if (currentRule) {
+                // Actualizar el estado del modal de relaciones
+            }
+        }
+    }, [elementTranslationRules, selectedRuleElement, showModal, relationTranslationRules, selectedRuleRelation, showRelationModal]);
 
     // Event handlers
     const handleElementSelection = (
@@ -73,6 +93,17 @@ export default function VisualSemanticEditor({
     const handleSaveRule = (elementName: string, rule: TranslationRule) => {
         onTranslationRuleChange(elementName, rule);
         setShowModal(false);
+    };
+
+    // Event handlers para relaciones
+    const handleOpenRelationModal = (relationName: string) => {
+        setSelectedRuleRelation(relationName);
+        setShowRelationModal(true);
+    };
+
+    const handleSaveRelationRule = (relationName: string, rule: RelationTranslationRule) => {
+        onRelationTranslationRuleChange(relationName, rule);
+        setShowRelationModal(false);
     };
 
     return (
@@ -146,6 +177,27 @@ export default function VisualSemanticEditor({
                 </Col>
             </Form.Group>
 
+            {relationTypes.length > 0 && (
+                    <Form.Group as={Row} className="mb-3 align-items-center">
+                        <Form.Label column sm={2}>Relation Translation Rules</Form.Label>
+                        <Col sm={10}>
+                            <div className="d-flex flex-wrap gap-2">
+                                {relationTypes.map(relation => (
+                                    <Button
+                                        key={relation}
+                                        variant="outline-secondary"
+                                        onClick={() => handleOpenRelationModal(relation)}
+                                    >
+                                        {relation}
+                                        {relationTranslationRules[relation] && (
+                                            <span className="ms-1">✓</span>
+                                        )}
+                                    </Button>
+                                ))}
+                            </div>
+                        </Col>
+                    </Form.Group>
+                )}
             </Form>
 
             {selectedRuleElement && (
@@ -160,6 +212,20 @@ export default function VisualSemanticEditor({
                     }}
                     onSave={(rule) => handleSaveRule(selectedRuleElement, rule)}
                     onClose={() => setShowModal(false)}
+                />
+            )}
+
+            {selectedRuleRelation && (
+                <RelationTranslationRuleModal
+                    show={showRelationModal}
+                    relationName={selectedRuleRelation}
+                    rule={relationTranslationRules[selectedRuleRelation] || {
+                        params: [],
+                        constraint: ''
+                    }}
+                    selectedElements={selectedElements}
+                    onSave={handleSaveRelationRule}
+                    onClose={() => setShowRelationModal(false)}
                 />
             )}
         </>

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { useLanguageContext } from '../../../context/LanguageContext/LanguageContextProvider';
+import { Form, Col, Row } from 'react-bootstrap';
+import Select from "react-select";
+
+export default function VisualSemanticEditor() {
+
+    // Importar todo lo necesario de useLanguageContext
+    const { semantics, setSemantics } = useLanguageContext();
+    const { elements } = useLanguageContext();
+    const { relationships, setRelationships } = useLanguageContext();
+    const { restrictions, setRestrictions } = useLanguageContext();
+
+    const [selectedElements, setSelectedElements] = useState<string[]>([]);
+    const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+
+    useEffect(() => {
+        // Parsear semantics al cargar la vista
+        if (isInitialLoad && semantics) {
+            try {
+                const parsedSemantics = JSON.parse(semantics);
+                setSelectedElements(parsedSemantics.elementTypes || []);
+                setIsInitialLoad(false);
+            } catch (e) {
+                console.error("Error al parsear JSON de semantics:", e);
+            }
+        }
+    }, [semantics, isInitialLoad]);
+
+    useEffect(() => {
+        if (!isInitialLoad) {
+            updateSemanticProperty();
+        }
+    }, [selectedElements, isInitialLoad]);
+
+    // Actualizar la propiedad elementTypes de la semántica
+    const updateSemanticProperty = () => {
+        try {
+            const newSemantics = semantics ? JSON.parse(semantics) : {};
+            newSemantics.elementTypes = selectedElements;
+            setSemantics(JSON.stringify(newSemantics, null, 2));
+        } catch (e) {
+            console.error("Error actualizando la propiedad elementTypes:", e);
+        }
+    };
+
+    return(
+        <>
+        <Form>
+            <Form.Group as={Row} className="mb-3">
+                {/* Primer elemento, ElementTypes */}
+                <Form.Label column sm={2}>Element Types</Form.Label>
+                <Col sm={10}>
+                    <Select
+                        options={elements.map((element) => ({
+                            value: element.name,
+                            label: element.name,
+                        }))}
+                        value={selectedElements.map((element) => ({
+                            value: element,
+                            label: element,
+                        }))}
+                        onChange={(selectedOptions) => {
+                            const updatedElements = selectedOptions.map((option) => option.value);
+                            setSelectedElements(updatedElements);
+                        }}
+                        isMulti
+                        closeMenuOnSelect={false}
+                        placeholder="Select element type(s)"
+                    />
+                </Col>
+            </Form.Group>
+        </Form>
+
+        </>
+    );
+}

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Form, Col, Row, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
-import Select, { MultiValue } from "react-select";
+import Select from "react-select";
 import CreatableSelect from "react-select/creatable";
 import TranslationRuleModal from './TranslationRule';
 import RelationTranslationRuleModal from './RelationTranslationRule';
@@ -154,12 +154,6 @@ export default function VisualSemanticEditor({
     }, [elementTranslationRules, selectedRuleElement, showModal, relationTranslationRules, selectedRuleRelation, showRelationModal]);
 
     // Event handlers
-    const handleElementSelection = (
-        selectedOptions: MultiValue<SelectOption>
-    ) => {
-        const updatedElements = selectedOptions.map(option => option.value);
-        onElementsChange(updatedElements);
-    };
 
     const handleOpenModal = (elementName: string) => {
         setSelectedRuleElement(elementName);
@@ -227,20 +221,29 @@ export default function VisualSemanticEditor({
                         </OverlayTrigger>
                     </Form.Label>
                     <Col sm={9}>
-                        <Select<SelectOption, true>
-                            options={elements.map(element => ({
-                                value: element.name,
-                                label: element.name,
-                            }))}
-                            value={selectedElements.map(element => ({
-                                value: element,
-                                label: element,
-                            }))}
-                            onChange={handleElementSelection}
-                            isMulti
-                            closeMenuOnSelect={false}
-                            placeholder="Select element type(s)"
-                        />
+                        <div className="d-flex flex-wrap gap-2">
+                            {elements.map(element => (
+                                <Button
+                                    key={element.name}
+                                    variant={selectedElements.includes(element.name) ? "primary" : "outline-primary"}
+                                    onClick={() => {
+                                        const currentSelection = [...selectedElements];
+                                        if (currentSelection.includes(element.name)) {
+                                            const index = currentSelection.indexOf(element.name);
+                                            currentSelection.splice(index, 1);
+                                        } else {
+                                            currentSelection.push(element.name);
+                                        }
+                                        onElementsChange(currentSelection);
+                                    }}
+                                >
+                                    {element.name}
+                                    {selectedElements.includes(element.name) && (
+                                        <span className="ms-1">✓</span>
+                                    )}
+                                </Button>
+                            ))}
+                        </div>
                     </Col>
                 </Form.Group>
 
@@ -413,24 +416,29 @@ export default function VisualSemanticEditor({
                         </OverlayTrigger>
                     </Form.Label>
                     <Col sm={9}>
-                        <Select<SelectOption, true>
-                            options={elements.map(element => ({
-                                value: element.name,
-                                label: element.name,
-                            }))}
-                            value={relationReificationTypes.map(type => ({
-                                value: type,
-                                label: type,
-                            }))}
-                            onChange={(selectedOptions) =>
-                                onRelationReificationTypesChange(
-                                    selectedOptions.map(option => option.value)
-                                )
-                            }
-                            isMulti
-                            closeMenuOnSelect={false}
-                            placeholder="Select or add reification types"
-                        />
+                        <div className="d-flex flex-wrap gap-2">
+                            {elements.map(element => (
+                                <Button
+                                    key={element.name}
+                                    variant={relationReificationTypes.includes(element.name) ? "primary" : "outline-primary"}
+                                    onClick={() => {
+                                        const currentSelection = [...relationReificationTypes];
+                                        if (currentSelection.includes(element.name)) {
+                                            const index = currentSelection.indexOf(element.name);
+                                            currentSelection.splice(index, 1);
+                                        } else {
+                                            currentSelection.push(element.name);
+                                        }
+                                        onRelationReificationTypesChange(currentSelection);
+                                    }}
+                                >
+                                    {element.name}
+                                    {relationReificationTypes.includes(element.name) && (
+                                        <span className="ms-1">✓</span>
+                                    )}
+                                </Button>
+                            ))}
+                        </div>
                     </Col>
                 </Form.Group>
 
@@ -529,28 +537,29 @@ export default function VisualSemanticEditor({
                         </OverlayTrigger>
                     </Form.Label>
                     <Col sm={9}>
-                        <CreatableSelect<SelectOption, true>
-                            options={elements.map(element => ({
-                                value: element.name,
-                                label: element.name,
-                            }))}
-                            value={hierarchyTypes.map(type => ({
-                                value: type,
-                                label: type,
-                            }))}
-                            onChange={(selectedOptions) =>
-                                onHierarchyTypesChange(selectedOptions.map(option => option.value))
-                            }
-                            isMulti
-                            closeMenuOnSelect={false}
-                            placeholder="Select or add hierarchy type(s)"
-                            formatCreateLabel={(inputValue) => `Add "${inputValue}"`}
-                            onCreateOption={(inputValue) => {
-                                if (!hierarchyTypes.includes(inputValue)) {
-                                    onHierarchyTypesChange([...hierarchyTypes, inputValue]);
-                                }
-                            }}
-                        />
+                        <div className="d-flex flex-wrap gap-2">
+                            {elements.map(element => (
+                                <Button
+                                    key={element.name}
+                                    variant={hierarchyTypes.includes(element.name) ? "primary" : "outline-primary"}
+                                    onClick={() => {
+                                        const currentSelection = [...hierarchyTypes];
+                                        if (currentSelection.includes(element.name)) {
+                                            const index = currentSelection.indexOf(element.name);
+                                            currentSelection.splice(index, 1);
+                                        } else {
+                                            currentSelection.push(element.name);
+                                        }
+                                        onHierarchyTypesChange(currentSelection);
+                                    }}
+                                >
+                                    {element.name}
+                                    {hierarchyTypes.includes(element.name) && (
+                                        <span className="ms-1">✓</span>
+                                    )}
+                                </Button>
+                            ))}
+                        </div>
                     </Col>
                 </Form.Group>
 

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useLanguageContext } from '../../../context/LanguageContext/LanguageContextProvider';
-import { Form, Col, Row } from 'react-bootstrap';
+import { Form, Col, Row, Button } from 'react-bootstrap';
 import Select from "react-select";
+import TranslationRuleModal from './TranslationRule';
+
+interface TranslationRule {
+    param: string;
+    constraint: string;
+    selectedConstraint: string;
+    deselectedConstraint: string;
+}
 
 export default function VisualSemanticEditor() {
 
@@ -13,6 +21,9 @@ export default function VisualSemanticEditor() {
 
     const [selectedElements, setSelectedElements] = useState<string[]>([]);
     const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+    const [selectedRuleElement, setSelectedRuleElement] = useState<string | null>(null);
+    const [showModal, setShowModal] = useState(false);
 
 
     useEffect(() => {
@@ -30,19 +41,46 @@ export default function VisualSemanticEditor() {
 
     useEffect(() => {
         if (!isInitialLoad) {
-            updateSemanticProperty();
+            updateElementTypes(selectedElements);
         }
     }, [selectedElements, isInitialLoad]);
 
-    // Actualizar la propiedad elementTypes de la semántica
-    const updateSemanticProperty = () => {
+
+    // Actualizar la semántica del JSON
+    const updateSemanticJSON = (key: string, value: any) => {
         try {
             const newSemantics = semantics ? JSON.parse(semantics) : {};
-            newSemantics.elementTypes = selectedElements;
+            newSemantics[key] = value;
             setSemantics(JSON.stringify(newSemantics, null, 2));
         } catch (e) {
-            console.error("Error actualizando la propiedad elementTypes:", e);
+            console.error(`Error updating the ${key} property in semantics:`, e);
         }
+    };
+
+    // Actualizar la propiedad elementTypes de la semántica
+    const updateElementTypes = (elements: string[]) => {
+        setSelectedElements(elements);
+        updateSemanticJSON("elementTypes", elements);
+    };
+
+    // Guarda la regla en el JSON de semantics
+    const saveTranslationRule  = (elementName: string, rule: TranslationRule) => {
+        try {
+            const parsedSemantics = semantics ? JSON.parse(semantics) : {};
+            const updatedRules = {
+                ...parsedSemantics.elementTranslationRules,
+                [elementName]: rule,
+            };
+            updateSemanticJSON("elementTranslationRules", updatedRules);
+            setShowModal(false);
+        } catch (e) {
+            console.error("Error updating elementTranslationRules:", e);
+        }
+    };
+
+    const handleOpenModal = (elementName: string) => {
+        setSelectedRuleElement(elementName);
+        setShowModal(true);
     };
 
     return(
@@ -71,8 +109,45 @@ export default function VisualSemanticEditor() {
                     />
                 </Col>
             </Form.Group>
+
+            {/* Section for Element Translation Rules */}
+            {selectedElements.length > 0 && (
+            <Form.Group as={Row} className="mb-3 align-items-center">
+                <Form.Label column sm={2}>Element Translation Rules</Form.Label>
+                <Col sm={10}>
+                    <div className="d-flex flex-wrap gap-2">
+                        {selectedElements.map((element) => (
+                            <Button
+                                key={element}
+                                variant="outline-primary"
+                                onClick={() => handleOpenModal(element)}
+                            >
+                                {element}
+                            </Button>
+                        ))}
+                    </div>
+                </Col>
+            </Form.Group>
+            )}
         </Form>
 
+        {/* Modal for Editing Translation Rules */}
+        {selectedRuleElement && (
+            <TranslationRuleModal
+                show={showModal}
+                elementName={selectedRuleElement}
+                rule={
+                    JSON.parse(semantics).elementTranslationRules?.[selectedRuleElement] || {
+                        param: '',
+                        constraint: '',
+                        selectedConstraint: '',
+                        deselectedConstraint: '',
+                    }
+                }
+                onSave={(updatedRule) => saveTranslationRule(selectedRuleElement as string, updatedRule)}
+                onClose={() => setShowModal(false)}
+            />
+        )}
         </>
     );
 }

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Form, Col, Row, Button } from 'react-bootstrap';
+import { Form, Col, Row, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import Select, { MultiValue } from "react-select";
 import CreatableSelect from "react-select/creatable";
 import TranslationRuleModal from './TranslationRule';
 import RelationTranslationRuleModal from './RelationTranslationRule';
 import AttributeRuleModal from './AttributeRuleModal';
 import HierarchyRuleModal from './hierarchyRuleModal';
+import { BiHelpCircle } from "react-icons/bi";
 
 // Interfaces
 interface TranslationRule {
@@ -187,8 +188,22 @@ export default function VisualSemanticEditor({
             <Form>
                 {/* Elements */}
                 <Form.Group as={Row} className="mb-3">
-                    <Form.Label column sm={2}>Element Types</Form.Label>
-                    <Col sm={10}>
+                    <Form.Label column sm={3}>
+                        Element Types
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Define the element types that are translated independently of other elements in the model. These types correspond to those declared in the abstract syntax and must be listed here for further semantic translation. Ensure all required element types are included.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm={9}>
                         <Select<SelectOption, true>
                             options={elements.map(element => ({
                                 value: element.name,
@@ -208,8 +223,22 @@ export default function VisualSemanticEditor({
 
                 {selectedElements.length > 0 && (
                     <Form.Group as={Row} className="mb-3 align-items-center">
-                        <Form.Label column sm={2}>Element Translation Rules</Form.Label>
-                        <Col sm={10}>
+                        <Form.Label column sm={3}>
+                            Element Translation Rules
+                            <OverlayTrigger
+                                placement="right"
+                                overlay={
+                                    <Tooltip>
+                                        Specify the translation rules for each element type listed in 'elementTypes'. Define attributes such as 'param' (placeholder for the element's ID), 'constraint' (default formula), and optional 'selectedConstraint' or 'deselectedConstraint' for specific states. Use these rules to construct the logical representation of the elements in the target semantics.
+                                    </Tooltip>
+                                }
+                            >
+                                <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                    <BiHelpCircle />
+                                </span>
+                            </OverlayTrigger>
+                        </Form.Label>
+                        <Col sm={9}>
                             <div className="d-flex flex-wrap gap-2">
                                 {selectedElements.map(element => (
                                     <Button
@@ -227,8 +256,22 @@ export default function VisualSemanticEditor({
 
                 {/* Relations */}
                 <Form.Group as={Row} className="mb-3">
-                    <Form.Label column sm={2}>Relation Types</Form.Label>
-                    <Col sm={10}>
+                    <Form.Label column sm={3}>
+                        Relation Types
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    List the allowed types of relations (edges) between nodes in the model. These types are critical for defining how relations are categorized and processed in the semantic translation. Ensure all required relation types are included
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm={9}>
                         <CreatableSelect<SelectOption, true>
                             options={
                                 Array.from(
@@ -269,8 +312,22 @@ export default function VisualSemanticEditor({
 
                 {relationTypes.length > 0 && (
                     <Form.Group as={Row} className="mb-3 align-items-center">
-                        <Form.Label column sm={2}>Relation Translation Rules</Form.Label>
-                        <Col sm={10}>
+                        <Form.Label column sm={3}>
+                            Relation Translation Rules
+                            <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Define the translation rules for each relation type listed in 'relationTypes'. Specify 'params' for placeholders representing source and target nodes, and 'constraint' to express the logical condition for the relation in the target semantics. These rules enable precise semantic representation of relations.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                        </Form.Label>
+                        <Col sm={9}>
                             <div className="d-flex flex-wrap gap-2">
                                 {relationTypes.map(relation => (
                                     <Button
@@ -290,8 +347,22 @@ export default function VisualSemanticEditor({
                 )}
 
                 <Form.Group as={Row} className="mb-3">
-                    <Form.Label column sm={2}>Relation Reification Types</Form.Label>
-                    <Col sm={10}>
+                    <Form.Label column sm={3}>
+                        Relation Reification Types
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Specifies the types of relations that are treated as reified relations in the model. Reified relations represent many-to-many, many-to-one, or one-to-many connections between elements and may include additional attributes or variables.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm={9}>
                         <Select<SelectOption, true>
                             options={elements.map(element => ({
                                 value: element.name,
@@ -313,9 +384,24 @@ export default function VisualSemanticEditor({
                     </Col>
                 </Form.Group>
 
+                {/* Attributes */}
                 <Form.Group as={Row} className="mb-3">
-                <Form.Label column sm={2}>Attribute Types</Form.Label>
-                <Col sm={10}>
+                <Form.Label column sm={3}>
+                    Attribute Types
+                    <OverlayTrigger
+                        placement="right"
+                        overlay={
+                            <Tooltip>
+                                Specify the element types for which attributes will be translated. These types determine which properties of the elements are considered during semantic translation. Ensure this list includes all relevant element types that use attributes in the model.
+                            </Tooltip>
+                        }
+                    >
+                        <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                            <BiHelpCircle />
+                        </span>
+                    </OverlayTrigger>
+                </Form.Label>
+                <Col sm={9}>
                     <Select<SelectOption, true>
                         options={elements.filter( element => element.properties.length > 0)
                             .map(element => ({
@@ -338,8 +424,22 @@ export default function VisualSemanticEditor({
 
                 {attributeTypes.length > 0 && (
                 <Form.Group as={Row} className="mb-3 align-items-center">
-                    <Form.Label column sm={2}>Attribute Translation Rules</Form.Label>
-                    <Col sm={10}>
+                    <Form.Label column sm={3}>
+                        Attribute Translation Rules
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Define how specific attributes are translated into logical constraints. Use 'parent' to refer to the associated element, 'param' to specify the field providing the value, and 'template' for the placeholder in the formula. The 'constraint' expresses the semantic rule using these placeholders. This is essential for models relying on attributes for contextual or operational semantics.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>    
+                    </Form.Label>
+                    <Col sm={9}>
                         <div className="d-flex flex-wrap gap-2">
                             {attributeTypes.map(attribute => {
                                 const hasRules = Object.keys(attributeTranslationRules).some(
@@ -361,9 +461,24 @@ export default function VisualSemanticEditor({
                 </Form.Group>
                 )}
 
+                {/* Hierarchy */}
                 <Form.Group as={Row} className="mb-3">
-                    <Form.Label column sm={2}>Hierarchy Types</Form.Label>
-                    <Col sm={10}>
+                    <Form.Label column sm={3}>
+                        Hierarchy Types
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Specify the types of elements that require translation based on their position in a hierarchical structure. These types often differ in semantics depending on whether they are at the root, intermediate nodes, or leaves in the hierarchy.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm={9}>
                         <CreatableSelect<SelectOption, true>
                             options={elements.map(element => ({
                                 value: element.name,
@@ -391,8 +506,22 @@ export default function VisualSemanticEditor({
 
                 {hierarchyTypes.length > 0 && (
                 <Form.Group as={Row} className="mb-3 align-items-center">
-                    <Form.Label column sm={2}>Hierarchy Translation Rules</Form.Label>
-                    <Col sm={10}>
+                    <Form.Label column sm={3}>
+                        Hierarchy Translation Rules
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Define translation rules for hierarchical structures. Use 'nodeRule' to specify constraints for nodes with hierarchical connections, mapping their IDs and related nodes via 'paramMapping'. Use 'leafRule' for constraints when the element is a leaf node.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm={9}>
                         <div className="d-flex flex-wrap gap-2">
                             {hierarchyTypes.map(hierarchyType => (
                                 <Button
@@ -411,83 +540,83 @@ export default function VisualSemanticEditor({
                 </Form.Group>
                 )}
 
-        </Form>
+            </Form>
 
-        {selectedRuleElement && (
-            <TranslationRuleModal
-                show={showModal}
-                elementName={selectedRuleElement}
-                rule={elementTranslationRules[selectedRuleElement] || {
-                    param: '',
-                    constraint: '',
-                    selectedConstraint: '',
-                    deselectedConstraint: '',
-                }}
-                onSave={(rule) => handleSaveRule(selectedRuleElement, rule)}
-                onClose={() => setShowModal(false)}
-            />
-        )}
-
-        {selectedRuleRelation && (
-            <RelationTranslationRuleModal
-                show={showRelationModal}
-                relationName={selectedRuleRelation}
-                rule={relationTranslationRules[selectedRuleRelation] || {
-                    params: [],
-                    constraint: ''
-                }}
-                selectedElements={selectedElements}
-                onSave={handleSaveRelationRule}
-                onClose={() => setShowRelationModal(false)}
-            />
-        )}
-
-        {selectedRuleAttribute && (
-            <AttributeRuleModal
-                show={showAttributeModal}
-                elementName={selectedRuleAttribute}
-                properties={
-                    elements
-                        .find(e => e.name === selectedRuleAttribute)
-                        ?.properties.map(prop => prop.name) || []
-                }
-                rule={
-                    attributeTranslationRules
-                }
-                onSave={(propertyName, rule) => {
-                    onAttributeTranslationRuleChange(propertyName, {
-                        ...rule
-                    });
-                    setShowAttributeModal(false);
-                }}
-                onClose={() => setShowAttributeModal(false)}
-            />
-        )}
-
-        {selectedRuleHierarchy && (
-            <HierarchyRuleModal
-                show={showHierarchyModal}
-                hierarchyType={selectedRuleHierarchy}
-                rule={hierarchyTranslationRules[selectedRuleHierarchy] || {
-                    nodeRule: {
-                        param: [],
-                        paramMapping: {
-                            incoming: false,
-                            var: '',
-                            node: '',
-                        },
-                        constraint: '',
-                    },
-                    leafRule: {
+            {selectedRuleElement && (
+                <TranslationRuleModal
+                    show={showModal}
+                    elementName={selectedRuleElement}
+                    rule={elementTranslationRules[selectedRuleElement] || {
                         param: '',
                         constraint: '',
-                    },
-                }}
-                elements={elements}
-                onSave={handleSaveHierarchyRule}
-                onClose={() => setShowHierarchyModal(false)}
-            />
-        )}
+                        selectedConstraint: '',
+                        deselectedConstraint: '',
+                    }}
+                    onSave={(rule) => handleSaveRule(selectedRuleElement, rule)}
+                    onClose={() => setShowModal(false)}
+                />
+            )}
+
+            {selectedRuleRelation && (
+                <RelationTranslationRuleModal
+                    show={showRelationModal}
+                    relationName={selectedRuleRelation}
+                    rule={relationTranslationRules[selectedRuleRelation] || {
+                        params: [],
+                        constraint: ''
+                    }}
+                    selectedElements={selectedElements}
+                    onSave={handleSaveRelationRule}
+                    onClose={() => setShowRelationModal(false)}
+                />
+            )}
+
+            {selectedRuleAttribute && (
+                <AttributeRuleModal
+                    show={showAttributeModal}
+                    elementName={selectedRuleAttribute}
+                    properties={
+                        elements
+                            .find(e => e.name === selectedRuleAttribute)
+                            ?.properties.map(prop => prop.name) || []
+                    }
+                    rule={
+                        attributeTranslationRules
+                    }
+                    onSave={(propertyName, rule) => {
+                        onAttributeTranslationRuleChange(propertyName, {
+                            ...rule
+                        });
+                        setShowAttributeModal(false);
+                    }}
+                    onClose={() => setShowAttributeModal(false)}
+                />
+            )}
+
+            {selectedRuleHierarchy && (
+                <HierarchyRuleModal
+                    show={showHierarchyModal}
+                    hierarchyType={selectedRuleHierarchy}
+                    rule={hierarchyTranslationRules[selectedRuleHierarchy] || {
+                        nodeRule: {
+                            param: [],
+                            paramMapping: {
+                                incoming: false,
+                                var: '',
+                                node: '',
+                            },
+                            constraint: '',
+                        },
+                        leafRule: {
+                            param: '',
+                            constraint: '',
+                        },
+                    }}
+                    elements={elements}
+                    onSave={handleSaveHierarchyRule}
+                    onClose={() => setShowHierarchyModal(false)}
+                />
+            )}
 
         </>
     );

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Form, Col, Row, Button } from 'react-bootstrap';
 import Select, { MultiValue } from "react-select";
+import CreatableSelect from "react-select/creatable";
 import TranslationRuleModal from './TranslationRule';
 
 // Interfaces
@@ -25,18 +26,22 @@ interface VisualSemanticEditorProps {
     elements: Element[];
     selectedElements: string[];
     elementTranslationRules: Record<string, TranslationRule>;
+    relationTypes: string[];
     
     // Event handlers
     onElementsChange: (elements: string[]) => void;
     onTranslationRuleChange: (elementName: string, rule: TranslationRule) => void;
+    onRelationsChange: (relations: string[]) => void;
 }
 
 export default function VisualSemanticEditor({
     elements,
     selectedElements,
     elementTranslationRules,
+    relationTypes,
     onElementsChange,
     onTranslationRuleChange,
+    onRelationsChange
 }: VisualSemanticEditorProps) {
 
     const [selectedRuleElement, setSelectedRuleElement] = useState<string | null>(null);
@@ -111,6 +116,36 @@ export default function VisualSemanticEditor({
                         </Col>
                     </Form.Group>
                 )}
+
+            <Form.Group as={Row} className="mb-3">
+                <Form.Label column sm={2}>Relation Types</Form.Label>
+                <Col sm={10}>
+                    <CreatableSelect<SelectOption, true>
+                        options={elements.map(element => ({
+                            value: element.name,
+                            label: element.name,
+                        }))}
+                        value={relationTypes.map(relation => ({
+                            value: relation,
+                            label: relation,
+                        }))}
+                        onChange={(selectedOptions) =>
+                            onRelationsChange(selectedOptions.map(option => option.value))
+                        }
+                        isMulti
+                        closeMenuOnSelect={false}
+                        placeholder="Select or add relation type(s)"
+                        formatCreateLabel={(inputValue) => `Add "${inputValue}"`}
+                        onCreateOption={(inputValue) => {
+                            // Actualiza el estado con la nueva opción personalizada
+                            if (!relationTypes.includes(inputValue)) {
+                                onRelationsChange([...relationTypes, inputValue]);
+                            }
+                        }}
+                    />
+                </Col>
+            </Form.Group>
+
             </Form>
 
             {selectedRuleElement && (

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -7,6 +7,7 @@ import RelationTranslationRuleModal from './RelationTranslationRule';
 import AttributeRuleModal from './AttributeRuleModal';
 import HierarchyRuleModal from './hierarchyRuleModal';
 import { BiHelpCircle } from "react-icons/bi";
+import PropertySchemaModal from './PropertySchemaModal';
 
 // Interfaces
 interface TranslationRule {
@@ -20,6 +21,13 @@ interface RelationTranslationRule {
     params: string[];
     constraint: string;
 }
+
+interface RelationPropertySchema {
+    type: {
+      index: number;
+      key: string;
+    }
+  }
 
 interface AttributeTranslationRule {
     parent: string;
@@ -69,6 +77,7 @@ interface VisualSemanticEditorProps {
     }>;
     relationTypes: string[];
     relationTranslationRules: Record<string, RelationTranslationRule>;
+    relationPropertySchema?: RelationPropertySchema;
     relationReificationTypes: string[];
     attributeTypes: string[];
     attributeTranslationRules: Record<string, AttributeTranslationRule>[];
@@ -80,6 +89,7 @@ interface VisualSemanticEditorProps {
     onTranslationRuleChange: (elementName: string, rule: TranslationRule) => void;
     onRelationsChange: (relations: string[]) => void;
     onRelationTranslationRuleChange: (relationName: string, rule: RelationTranslationRule) => void;
+    onRelationPropertySchemaChange?: (schema: RelationPropertySchema) => void;
     onRelationReificationTypesChange: (types: string[]) => void;
     onAttributeTypesChange: (attributeTypes: string[]) => void;
     onAttributeTranslationRuleChange: (attributeName: string, rule: AttributeTranslationRule) => void;
@@ -94,6 +104,7 @@ export default function VisualSemanticEditor({
     relationships,
     relationTypes,
     relationTranslationRules,
+    relationPropertySchema,
     relationReificationTypes,
     attributeTypes,
     attributeTranslationRules,
@@ -103,6 +114,7 @@ export default function VisualSemanticEditor({
     onTranslationRuleChange,
     onRelationsChange,
     onRelationTranslationRuleChange,
+    onRelationPropertySchemaChange,
     onRelationReificationTypesChange,
     onAttributeTypesChange,
     onAttributeTranslationRuleChange,
@@ -115,6 +127,8 @@ export default function VisualSemanticEditor({
 
     const [selectedRuleRelation, setSelectedRuleRelation] = useState<string | null>(null);
     const [showRelationModal, setShowRelationModal] = useState(false);
+
+    const [showRelationPropertySchemaModal, setShowRelationPropertySchemaModal] = useState(false);
 
     const [selectedRuleAttribute, setSelectedRuleAttribute] = useState<string | null>(null);
     const [showAttributeModal, setShowAttributeModal] = useState(false);
@@ -167,6 +181,15 @@ export default function VisualSemanticEditor({
         onRelationTranslationRuleChange(relationName, rule);
         setShowRelationModal(false);
     };
+
+    const handleOpenRelationPropertySchemaModal = () => {
+        setShowRelationPropertySchemaModal(true);
+    };
+
+    const handleSaveRelationPropertySchema = (schema: RelationPropertySchema) => {
+        onRelationPropertySchemaChange(schema);
+        setShowRelationPropertySchemaModal(false);
+    }
 
     const handleOpenAttributeModal = (attributeName: string) => {
         setSelectedRuleAttribute(attributeName);
@@ -345,6 +368,33 @@ export default function VisualSemanticEditor({
                         </Col>
                     </Form.Group>
                 )}
+
+                {/* Relation Property Schema */}
+                <Form.Group as={Row} className="mb-3">
+                    <Form.Label column sm={3}>
+                        Relation Property Schema
+                        <OverlayTrigger
+                            placement="right"
+                            overlay={
+                                <Tooltip>
+                                    Define the schema for relation properties. This schema specifies the type of the property and its key in the target semantics. The schema is essential for models with relations that include additional properties or variables.
+                                </Tooltip>
+                            }
+                        >
+                            <span className="ms-2 text-info" style={{cursor: 'help'}}>
+                                <BiHelpCircle />
+                            </span>
+                        </OverlayTrigger>
+                    </Form.Label>
+                    <Col sm={9}>
+                        <Button
+                            variant="outline-primary"
+                            onClick={() => handleOpenRelationPropertySchemaModal()}
+                        >
+                            {"Relation Property Schema"}
+                        </Button>
+                    </Col>
+                </Form.Group>
 
                 <Form.Group as={Row} className="mb-3">
                     <Form.Label column sm={3}>
@@ -568,6 +618,15 @@ export default function VisualSemanticEditor({
                     selectedElements={selectedElements}
                     onSave={handleSaveRelationRule}
                     onClose={() => setShowRelationModal(false)}
+                />
+            )}
+
+            {showRelationPropertySchemaModal && (
+                <PropertySchemaModal
+                    show={showRelationPropertySchemaModal}
+                    schema={relationPropertySchema || { type: { index: 0, key: '' } }}
+                    onSave={handleSaveRelationPropertySchema}
+                    onClose={() => setShowRelationPropertySchemaModal(false)}
                 />
             )}
 

--- a/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
+++ b/src/core/components/LanguageDetail/Semantics/VisualSemanticEditor.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { useLanguageContext } from '../../../context/LanguageContext/LanguageContextProvider';
 import { Form, Col, Row, Button } from 'react-bootstrap';
-import Select from "react-select";
+import Select, { MultiValue } from "react-select";
 import TranslationRuleModal from './TranslationRule';
 
+// Interfaces
 interface TranslationRule {
     param: string;
     constraint: string;
@@ -11,71 +11,53 @@ interface TranslationRule {
     deselectedConstraint: string;
 }
 
-export default function VisualSemanticEditor() {
+interface Element {
+    name: string;
+}
 
-    // Importar todo lo necesario de useLanguageContext
-    const { semantics, setSemantics } = useLanguageContext();
-    const { elements } = useLanguageContext();
-    const { relationships, setRelationships } = useLanguageContext();
-    const { restrictions, setRestrictions } = useLanguageContext();
+interface SelectOption {
+    value: string;
+    label: string;
+}
 
-    const [selectedElements, setSelectedElements] = useState<string[]>([]);
-    const [isInitialLoad, setIsInitialLoad] = useState(true);
+interface VisualSemanticEditorProps {
+    // Data props
+    elements: Element[];
+    selectedElements: string[];
+    elementTranslationRules: Record<string, TranslationRule>;
+    
+    // Event handlers
+    onElementsChange: (elements: string[]) => void;
+    onTranslationRuleChange: (elementName: string, rule: TranslationRule) => void;
+}
+
+export default function VisualSemanticEditor({
+    elements,
+    selectedElements,
+    elementTranslationRules,
+    onElementsChange,
+    onTranslationRuleChange,
+}: VisualSemanticEditorProps) {
 
     const [selectedRuleElement, setSelectedRuleElement] = useState<string | null>(null);
     const [showModal, setShowModal] = useState(false);
 
-
+    // Efecto para actualizar el modal cuando cambian las reglas
     useEffect(() => {
-        // Parsear semantics al cargar la vista
-        if (isInitialLoad && semantics) {
-            try {
-                const parsedSemantics = JSON.parse(semantics);
-                setSelectedElements(parsedSemantics.elementTypes || []);
-                setIsInitialLoad(false);
-            } catch (e) {
-                console.error("Error al parsear JSON de semantics:", e);
+        if (selectedRuleElement && showModal) {
+            const currentRule = elementTranslationRules[selectedRuleElement];
+            if (currentRule) {
+                // Actualizar el estado del modal
             }
         }
-    }, [semantics, isInitialLoad]);
+    }, [elementTranslationRules, selectedRuleElement, showModal]);
 
-    useEffect(() => {
-        if (!isInitialLoad) {
-            updateElementTypes(selectedElements);
-        }
-    }, [selectedElements, isInitialLoad]);
-
-
-    // Actualizar la semántica del JSON
-    const updateSemanticJSON = (key: string, value: any) => {
-        try {
-            const newSemantics = semantics ? JSON.parse(semantics) : {};
-            newSemantics[key] = value;
-            setSemantics(JSON.stringify(newSemantics, null, 2));
-        } catch (e) {
-            console.error(`Error updating the ${key} property in semantics:`, e);
-        }
-    };
-
-    // Actualizar la propiedad elementTypes de la semántica
-    const updateElementTypes = (elements: string[]) => {
-        setSelectedElements(elements);
-        updateSemanticJSON("elementTypes", elements);
-    };
-
-    // Guarda la regla en el JSON de semantics
-    const saveTranslationRule  = (elementName: string, rule: TranslationRule) => {
-        try {
-            const parsedSemantics = semantics ? JSON.parse(semantics) : {};
-            const updatedRules = {
-                ...parsedSemantics.elementTranslationRules,
-                [elementName]: rule,
-            };
-            updateSemanticJSON("elementTranslationRules", updatedRules);
-            setShowModal(false);
-        } catch (e) {
-            console.error("Error updating elementTranslationRules:", e);
-        }
+    // Event handlers
+    const handleElementSelection = (
+        selectedOptions: MultiValue<SelectOption>
+    ) => {
+        const updatedElements = selectedOptions.map(option => option.value);
+        onElementsChange(updatedElements);
     };
 
     const handleOpenModal = (elementName: string) => {
@@ -83,71 +65,68 @@ export default function VisualSemanticEditor() {
         setShowModal(true);
     };
 
-    return(
+    const handleSaveRule = (elementName: string, rule: TranslationRule) => {
+        onTranslationRuleChange(elementName, rule);
+        setShowModal(false);
+    };
+
+    return (
         <>
-        <Form>
-            <Form.Group as={Row} className="mb-3">
-                {/* Primer elemento, ElementTypes */}
-                <Form.Label column sm={2}>Element Types</Form.Label>
-                <Col sm={10}>
-                    <Select
-                        options={elements.map((element) => ({
-                            value: element.name,
-                            label: element.name,
-                        }))}
-                        value={selectedElements.map((element) => ({
-                            value: element,
-                            label: element,
-                        }))}
-                        onChange={(selectedOptions) => {
-                            const updatedElements = selectedOptions.map((option) => option.value);
-                            setSelectedElements(updatedElements);
-                        }}
-                        isMulti
-                        closeMenuOnSelect={false}
-                        placeholder="Select element type(s)"
-                    />
-                </Col>
-            </Form.Group>
+            <Form>
+                <Form.Group as={Row} className="mb-3">
+                    <Form.Label column sm={2}>Element Types</Form.Label>
+                    <Col sm={10}>
+                        <Select<SelectOption, true>
+                            options={elements.map(element => ({
+                                value: element.name,
+                                label: element.name,
+                            }))}
+                            value={selectedElements.map(element => ({
+                                value: element,
+                                label: element,
+                            }))}
+                            onChange={handleElementSelection}
+                            isMulti
+                            closeMenuOnSelect={false}
+                            placeholder="Select element type(s)"
+                        />
+                    </Col>
+                </Form.Group>
 
-            {/* Section for Element Translation Rules */}
-            {selectedElements.length > 0 && (
-            <Form.Group as={Row} className="mb-3 align-items-center">
-                <Form.Label column sm={2}>Element Translation Rules</Form.Label>
-                <Col sm={10}>
-                    <div className="d-flex flex-wrap gap-2">
-                        {selectedElements.map((element) => (
-                            <Button
-                                key={element}
-                                variant="outline-primary"
-                                onClick={() => handleOpenModal(element)}
-                            >
-                                {element}
-                            </Button>
-                        ))}
-                    </div>
-                </Col>
-            </Form.Group>
-            )}
-        </Form>
+                {selectedElements.length > 0 && (
+                    <Form.Group as={Row} className="mb-3 align-items-center">
+                        <Form.Label column sm={2}>Element Translation Rules</Form.Label>
+                        <Col sm={10}>
+                            <div className="d-flex flex-wrap gap-2">
+                                {selectedElements.map(element => (
+                                    <Button
+                                        key={element}
+                                        variant="outline-primary"
+                                        onClick={() => handleOpenModal(element)}
+                                    >
+                                        {element}
+                                    </Button>
+                                ))}
+                            </div>
+                        </Col>
+                    </Form.Group>
+                )}
+            </Form>
 
-        {/* Modal for Editing Translation Rules */}
-        {selectedRuleElement && (
-            <TranslationRuleModal
-                show={showModal}
-                elementName={selectedRuleElement}
-                rule={
-                    JSON.parse(semantics).elementTranslationRules?.[selectedRuleElement] || {
+            {selectedRuleElement && (
+                <TranslationRuleModal
+                    show={showModal}
+                    elementName={selectedRuleElement}
+                    rule={elementTranslationRules[selectedRuleElement] || {
                         param: '',
                         constraint: '',
                         selectedConstraint: '',
                         deselectedConstraint: '',
-                    }
-                }
-                onSave={(updatedRule) => saveTranslationRule(selectedRuleElement as string, updatedRule)}
-                onClose={() => setShowModal(false)}
-            />
-        )}
+                    }}
+                    onSave={(rule) => handleSaveRule(selectedRuleElement, rule)}
+                    onClose={() => setShowModal(false)}
+                />
+            )}
         </>
     );
 }

--- a/src/core/components/LanguageDetail/Semantics/hierarchyRuleModal.tsx
+++ b/src/core/components/LanguageDetail/Semantics/hierarchyRuleModal.tsx
@@ -1,0 +1,330 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, Button, Form, Row, Col } from 'react-bootstrap';
+import MultiValueForm from '../GraphicalMode/Utils/FormUtils/MultiValueForm';
+
+// Interfaces
+interface HierarchyTranslationRule {
+    nodeRule?: {
+        param: string[];
+        paramMapping: {
+            incoming: boolean;
+            var: string;
+            node: string;
+        };
+        constraint: string;
+    };
+    leafRule?: {
+        param: string;
+        constraint: string;
+    };
+}
+
+interface HierarchyRuleModalProps {
+    show: boolean;
+    hierarchyType: string;
+    rule: HierarchyTranslationRule;
+    elements: { name: string }[]; // Para selección de elementos
+    onSave: (hierarchyType: string, rule: HierarchyTranslationRule) => void;
+    onClose: () => void;
+}
+
+export default function HierarchyRuleModal({
+    show,
+    hierarchyType,
+    rule,
+    elements,
+    onSave,
+    onClose
+}: HierarchyRuleModalProps) {
+    // Estado local para manejar la regla
+    const [localRule, setLocalRule] = useState<HierarchyTranslationRule>({
+        nodeRule: {
+            param: [],
+            paramMapping: {
+                incoming: false,
+                var: '',
+                node: ''
+            },
+            constraint: ''
+        },
+        leafRule: {
+            param: '',
+            constraint: ''
+        }
+    });
+
+    // Estado para manejo de validaciones
+    //const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+    // Efecto para actualizar estado local cuando cambia la regla externa
+    useEffect(() => {
+        // Asegurarse de tener valores por defecto
+        setLocalRule({
+            nodeRule: rule.nodeRule || {
+                param: [],
+                paramMapping: {
+                    incoming: false,
+                    var: '',
+                    node: ''
+                },
+                constraint: ''
+            },
+            leafRule: rule.leafRule || {
+                param: '',
+                constraint: ''
+            }
+        });
+    }, [rule, show]);
+
+    // Validación de reglas
+    // const validateRules = (): boolean => {
+    //     const errors: string[] = [];
+
+    //     // Validaciones para nodeRule
+    //     if (localRule.nodeRule) {
+    //         if (localRule.nodeRule.param.length === 0) {
+    //             errors.push("Node Rule: Debe tener al menos un parámetro");
+    //         }
+    //         if (!localRule.nodeRule.paramMapping.var) {
+    //             errors.push("Node Rule: Debe definir un nombre de variable");
+    //         }
+    //         if (!localRule.nodeRule.paramMapping.node) {
+    //             errors.push("Node Rule: Debe definir un nombre de nodo");
+    //         }
+    //         if (!localRule.nodeRule.constraint.trim()) {
+    //             errors.push("Node Rule: La restricción no puede estar vacía");
+    //         }
+    //     }
+
+    //     // Validaciones para leafRule
+    //     if (localRule.leafRule) {
+    //         if (!localRule.leafRule.param) {
+    //             errors.push("Leaf Rule: Debe tener un parámetro");
+    //         }
+    //         if (!localRule.leafRule.constraint.trim()) {
+    //             errors.push("Leaf Rule: La restricción no puede estar vacía");
+    //         }
+    //     }
+
+    //     setValidationErrors(errors);
+    //     return errors.length === 0;
+    // };
+
+    // Manejadores para cambios en NodeRule
+    const handleNodeRuleParamChange = (params: string[]) => {
+        setLocalRule(prev => ({
+            ...prev,
+            nodeRule: {
+                ...prev.nodeRule!,
+                param: params
+            }
+        }));
+    };
+
+    const handleNodeRuleMappingChange = (
+        field: keyof HierarchyTranslationRule['nodeRule']['paramMapping'], 
+        value: string | boolean
+    ) => {
+        setLocalRule(prev => ({
+            ...prev,
+            nodeRule: {
+                ...prev.nodeRule!,
+                paramMapping: {
+                    ...prev.nodeRule!.paramMapping,
+                    [field]: value
+                }
+            }
+        }));
+    };
+
+    const handleNodeRuleConstraintChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setLocalRule(prev => ({
+            ...prev,
+            nodeRule: {
+                ...prev.nodeRule!,
+                constraint: event.target.value
+            }
+        }));
+    };
+
+    // Manejadores para cambios en LeafRule
+    const handleLeafRuleParamChange = (value: string) => {
+        setLocalRule(prev => ({
+            ...prev,
+            leafRule: {
+                ...prev.leafRule!,
+                param: value
+            }
+        }));
+    };
+
+    const handleLeafRuleConstraintChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setLocalRule(prev => ({
+            ...prev,
+            leafRule: {
+                ...prev.leafRule!,
+                constraint: event.target.value
+            }
+        }));
+    };
+
+    // Manejador de envío
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        onSave(hierarchyType, localRule);
+
+        // if (validateRules()) {
+        //     onSave(hierarchyType, localRule);
+        // }
+    };
+
+    return (
+        <Modal show={show} onHide={onClose} size="xl">
+            <Form onSubmit={handleSubmit}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Hierarchy Translation Rule: {hierarchyType}</Modal.Title>
+                </Modal.Header>
+                
+                <Modal.Body>
+                    {/* {validationErrors.length > 0 && (
+                        <Alert variant="danger">
+                            <ul>
+                                {validationErrors.map((error, index) => (
+                                    <li key={index}>{error}</li>
+                                ))}
+                            </ul>
+                        </Alert>
+                    )} */}
+
+                    {/* Sección de Node Rule */}
+                    <fieldset className="border p-3 mb-3">
+                        <legend>Node Rule (Internal Nodes)</legend>
+                        
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label column sm={3}>Parameters</Form.Label>
+                            <Col sm={9}>
+                                <MultiValueForm
+                                    selectedItems={localRule.nodeRule?.param || []}
+                                    setSelectedItems={handleNodeRuleParamChange}
+                                />
+                                <Form.Text className="text-muted">
+                                    Select parameters for node translation (first for node ID, second for related nodes)
+                                </Form.Text>
+                            </Col>
+                        </Form.Group>
+
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label column sm={3}>Parameter Mapping</Form.Label>
+                            <Col sm={9}>
+                                <Row>
+                                    <Col>
+                                        <Form.Check 
+                                            type="switch"
+                                            label="Incoming Hierarchy"
+                                            checked={localRule.nodeRule?.paramMapping.incoming || false}
+                                            onChange={(e) => handleNodeRuleMappingChange('incoming', e.target.checked)}
+                                        />
+                                    </Col>
+                                    <Col>
+                                        <Form.Control 
+                                            type="text"
+                                            placeholder="Variable Name"
+                                            value={localRule.nodeRule?.paramMapping.var || ''}
+                                            onChange={(e) => handleNodeRuleMappingChange('var', e.target.value)}
+                                        />
+                                    </Col>
+                                    <Col>
+                                        <Form.Control 
+                                            type="text"
+                                            placeholder="Node Parameter Name"
+                                            value={localRule.nodeRule?.paramMapping.node || ''}
+                                            onChange={(e) => handleNodeRuleMappingChange('node', e.target.value)}
+                                        />
+                                    </Col>
+                                </Row>
+                                <Form.Text className="text-muted">
+                                    Configure how hierarchy and node parameters are mapped
+                                </Form.Text>
+                            </Col>
+                        </Form.Group>
+
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label column sm={3}>Node Constraint</Form.Label>
+                            <Col sm={9}>
+                                <Form.Control
+                                    as="textarea"
+                                    rows={4}
+                                    value={localRule.nodeRule?.constraint || ''}
+                                    onChange={handleNodeRuleConstraintChange}
+                                    placeholder="Enter node constraint (e.g., using sum(), len() expansions)"
+                                />
+                                <Form.Text className="text-muted">
+                                    Define constraint for internal nodes. Use expansions like sum(Xs)/len(Xs)
+                                </Form.Text>
+                            </Col>
+                        </Form.Group>
+                    </fieldset>
+
+                    {/* Sección de Leaf Rule */}
+                    <fieldset className="border p-3">
+                        <legend>Leaf Rule</legend>
+                        
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label column sm={3}>Parameter</Form.Label>
+                            <Col sm={9}>
+                                {/* <Form.Select
+                                    value={localRule.leafRule?.param || ''}
+                                    onChange={handleLeafRuleParamChange}
+                                >
+                                    <option value="">Select Parameter</option>
+                                    {elements.map(element => (
+                                        <option key={element.name} value={element.name}>
+                                            {element.name}
+                                        </option>
+                                    ))}
+                                </Form.Select> */}
+                                <Form.Control
+                                    type="text"
+                                    placeholder="Enter parameter for leaf node"
+                                    value={localRule.leafRule?.param || ''}
+                                    onChange={(e) => handleLeafRuleParamChange(e.target.value)}
+                                />
+                                <Form.Text className="text-muted">
+                                    Select the parameter for leaf node translation
+                                </Form.Text>
+                            </Col>
+                        </Form.Group>
+
+                        <Form.Group as={Row} className="mb-3">
+                            <Form.Label column sm={3}>Leaf Constraint</Form.Label>
+                            <Col sm={9}>
+                                <Form.Control
+                                    as="textarea"
+                                    rows={4}
+                                    value={localRule.leafRule?.constraint || ''}
+                                    onChange={handleLeafRuleConstraintChange}
+                                    placeholder="Enter leaf node constraint"
+                                />
+                                <Form.Text className="text-muted">
+                                    Define constraint specifically for leaf nodes
+                                </Form.Text>
+                            </Col>
+                        </Form.Group>
+                    </fieldset>
+                </Modal.Body>
+
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button 
+                        variant="primary" 
+                        type="submit"
+                    >
+                        Save Hierarchy Rule
+                    </Button>
+                </Modal.Footer>
+            </Form>
+        </Modal>
+    );
+}

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -69,6 +69,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
   const [attributeTypes, setAttributeTypes] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
   const [hierarchyTypes, setHierarchyTypes] = useState<string[]>([]);
+  const [relationReificationTypes, setRelationReificationTypes] = useState<string[]>([]);
 
   const [state, setState] = useState<SemanticsState>({
     isLoading: true,
@@ -114,7 +115,11 @@ export default function Semantics({ isActive }: SemanticsProps) {
         parsed.hasOwnProperty('relationTranslationRules') &&
         Array.isArray(parsed.relationTranslationRules) &&
         parsed.hasOwnProperty('hierarchyTypes') &&
-        Array.isArray(parsed.hierarchyTypes)
+        Array.isArray(parsed.hierarchyTypes) &&
+        parsed.hasOwnProperty('hierarchyTranslationRules') &&
+        Array.isArray(parsed.hierarchyTranslationRules) &&
+        parsed.hasOwnProperty('relationReificationTypes') &&
+        Array.isArray(parsed.relationReificationTypes)
       );
     } catch (e) {
       return false;
@@ -164,6 +169,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
         ),
         elementTranslationRules: {},
         relationTranslationRules: {},
+        relationReificationTypes: [],
         attributeTypes: [],
         hierarchyTypes: [],
         typingRelationTypes: ["IndividualCardinality"],
@@ -208,6 +214,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
         elementTranslationRules: parsedSemantics.elementTranslationRules || {},
         relationTypes: parsedSemantics.relationTypes || [],
         relationTranslationRules: parsedSemantics.relationTranslationRules || {},
+        relationReificationTypes: parsedSemantics.relationReificationTypes || [],
         attributeTypes: parsedSemantics.attributeTypes || [],
         attributeTranslationRules: parsedSemantics.attributeTranslationRules || {},
         hierarchyTypes: parsedSemantics.hierarchyTypes || [],
@@ -221,6 +228,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
         elementTranslationRules: {},
         relationTypes: [],
         relationTranslationRules: {},
+        relationReificationTypes: [],
         attributeTypes: [],
         attributeTranslationRules: {},
         hierarchyTypes: [],
@@ -239,6 +247,8 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setAttributeTypes(attributeTypes);
     const { hierarchyTypes } = parseCurrentSemantics();
     setHierarchyTypes(hierarchyTypes);
+    const { relationReificationTypes } = parseCurrentSemantics();
+    setRelationReificationTypes(relationReificationTypes);
   }, [semantics, parseCurrentSemantics]);
 
   // Manejar el cambio de elementos seleccionados
@@ -261,7 +271,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
     };
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
     setRelationTypes(relations);
-};
+  };
 
   const handleTranslationRuleChange = (elementName: string, rule: TranslationRule) => {
     const currentSemantics = parseCurrentSemantics();
@@ -290,6 +300,17 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
   };
 
+  const handleRelationReificationTypes = (relationReificationTypes: string[]) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      relationReificationTypes: relationReificationTypes,
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+    setRelationReificationTypes(relationReificationTypes);
+  }
+
+  // Attributes
   const handleAttributeTypesChange = (attributes: string[]) => {
     const currentSemantics = parseCurrentSemantics();
     const updatedSemantics = {
@@ -478,8 +499,10 @@ export default function Semantics({ isActive }: SemanticsProps) {
               elements={elements}
               selectedElements={selectedElements}
               elementTranslationRules={parseCurrentSemantics().elementTranslationRules}
+              relationships={relationships}
               relationTypes={relationTypes}
               relationTranslationRules={parseCurrentSemantics().relationTranslationRules}
+              relationReificationTypes={relationReificationTypes}
               attributeTypes={attributeTypes}
               attributeTranslationRules={parseCurrentSemantics().attributeTranslationRules}
               hierarchyTypes={hierarchyTypes}
@@ -488,6 +511,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
               onTranslationRuleChange={handleTranslationRuleChange}
               onRelationsChange={handleRelationsChange}
               onRelationTranslationRuleChange={handleRelationTranslationRuleChange}
+              onRelationReificationTypesChange={handleRelationReificationTypes}
               onAttributeTypesChange={handleAttributeTypesChange}
               onAttributeTranslationRuleChange={handleAttributeTranslationRuleChange}
               onHierarchyTypesChange={handleHierarchyChange}

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -30,6 +30,13 @@ interface RelationTranslationRule {
   constraint: string;
 }
 
+interface RelationPropertySchema {
+  type: {
+    index: number;
+    key: string;
+  }
+}
+
 interface AttributeTranslationRule {
   parent: string;
   param: string;
@@ -186,6 +193,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
         elementTranslationRules: parsedSemantics.elementTranslationRules || {},
         relationTypes: parsedSemantics.relationTypes || [],
         relationTranslationRules: parsedSemantics.relationTranslationRules || {},
+        relationPropertySchema: parsedSemantics.relationPropertySchema || {},
         relationReificationTypes: parsedSemantics.relationReificationTypes || [],
         attributeTypes: parsedSemantics.attributeTypes || [],
         attributeTranslationRules: parsedSemantics.attributeTranslationRules || {},
@@ -201,6 +209,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
         elementTranslationRules: {},
         relationTypes: [],
         relationTranslationRules: {},
+        relationPropertySchema: {},
         relationReificationTypes: [],
         attributeTypes: [],
         attributeTranslationRules: {},
@@ -260,6 +269,15 @@ export default function Semantics({ isActive }: SemanticsProps) {
     };
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
   };
+
+  const handleRelationPropertySchemaChange = (schema: RelationPropertySchema) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      relationPropertySchema: schema
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+  }
 
   const handleRelationTranslationRuleChange = (
     relationName: string,
@@ -478,6 +496,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
               relationships={relationships}
               relationTypes={relationTypes}
               relationTranslationRules={parseCurrentSemantics().relationTranslationRules}
+              relationPropertySchema={parseCurrentSemantics().relationPropertySchema}
               relationReificationTypes={relationReificationTypes}
               attributeTypes={attributeTypes}
               attributeTranslationRules={parseCurrentSemantics().attributeTranslationRules}
@@ -487,6 +506,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
               onTranslationRuleChange={handleTranslationRuleChange}
               onRelationsChange={handleRelationsChange}
               onRelationTranslationRuleChange={handleRelationTranslationRuleChange}
+              onRelationPropertySchemaChange={handleRelationPropertySchemaChange}
               onRelationReificationTypesChange={handleRelationReificationTypes}
               onAttributeTypesChange={handleAttributeTypesChange}
               onAttributeTranslationRuleChange={handleAttributeTranslationRuleChange}

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -37,6 +37,23 @@ interface RelationPropertySchema {
   }
 }
 
+interface RelationReificationTranslationRules {
+  param: string[];
+  paramMapping: {
+    inboundEdges: {
+      unique: boolean;
+      var: string;
+    };
+    outboundEdges: {
+      unique: boolean;
+      var: string;
+    };
+  };
+  constraint: {
+      [key: string]: string;
+  };
+}
+
 interface AttributeTranslationRule {
   parent: string;
   param: string;
@@ -71,10 +88,12 @@ export default function Semantics({ isActive }: SemanticsProps) {
     elements, 
     relationships
   } = useLanguageContext();
+
+  const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
+
   const [selectedElements, setSelectedElements] = useState<string[]>([]);
   const [relationTypes, setRelationTypes] = useState<string[]>([]);
   const [attributeTypes, setAttributeTypes] = useState<string[]>([]);
-  const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
   const [hierarchyTypes, setHierarchyTypes] = useState<string[]>([]);
   const [relationReificationTypes, setRelationReificationTypes] = useState<string[]>([]);
 
@@ -156,7 +175,6 @@ export default function Semantics({ isActive }: SemanticsProps) {
         relationTypes: [],
         elementTranslationRules: {},
         relationTranslationRules: {},
-        relationReificationTypes: [],
       };
 
       setSemantics(JSON.stringify(initialSemantics, null, 2));
@@ -194,11 +212,12 @@ export default function Semantics({ isActive }: SemanticsProps) {
         relationTypes: parsedSemantics.relationTypes || [],
         relationTranslationRules: parsedSemantics.relationTranslationRules || {},
         relationPropertySchema: parsedSemantics.relationPropertySchema || {},
-        relationReificationTypes: parsedSemantics.relationReificationTypes || [],
         attributeTypes: parsedSemantics.attributeTypes || [],
         attributeTranslationRules: parsedSemantics.attributeTranslationRules || {},
         hierarchyTypes: parsedSemantics.hierarchyTypes || [],
         hierarchyTranslationRules: parsedSemantics.hierarchyTranslationRules || {},
+        relationReificationTypes: parsedSemantics.relationReificationTypes || [],
+        relationReificationTranslationRules: parsedSemantics.relationReificationTranslationRules || {},
         relationReificationExpansions: parsedSemantics.relationReificationExpansions || [],
         // Añadir otros campos según sea necesario (Los siguientes pueden ser typingRelationTypes, etc.)
       };
@@ -210,11 +229,12 @@ export default function Semantics({ isActive }: SemanticsProps) {
         relationTypes: [],
         relationTranslationRules: {},
         relationPropertySchema: {},
-        relationReificationTypes: [],
         attributeTypes: [],
         attributeTranslationRules: {},
         hierarchyTypes: [],
         hierarchyTranslationRules: {},
+        relationReificationTypes: [],
+        relationReificationTranslationRules: {},
       };
     }
   }, [semantics]);
@@ -246,18 +266,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
     setSelectedElements(elements);
   };
-
-  // Manejar el cambio de relationTypes
-  const handleRelationsChange = (relations: string[]) => {
-    const currentSemantics = parseCurrentSemantics();
-    const updatedSemantics = {
-        ...currentSemantics,
-        relationTypes: relations,
-    };
-    setSemantics(JSON.stringify(updatedSemantics, null, 2));
-    setRelationTypes(relations);
-  };
-
+  
   const handleTranslationRuleChange = (elementName: string, rule: TranslationRule) => {
     const currentSemantics = parseCurrentSemantics();
     const updatedSemantics = {
@@ -270,14 +279,16 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
   };
 
-  const handleRelationPropertySchemaChange = (schema: RelationPropertySchema) => {
+  // Manejar el cambio de relationTypes
+  const handleRelationsChange = (relations: string[]) => {
     const currentSemantics = parseCurrentSemantics();
     const updatedSemantics = {
-      ...currentSemantics,
-      relationPropertySchema: schema
+        ...currentSemantics,
+        relationTypes: relations,
     };
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
-  }
+    setRelationTypes(relations);
+  };
 
   const handleRelationTranslationRuleChange = (
     relationName: string,
@@ -294,6 +305,15 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
   };
 
+  const handleRelationPropertySchemaChange = (schema: RelationPropertySchema) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      relationPropertySchema: schema
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+  };
+
   const handleRelationReificationTypes = (relationReificationTypes: string[]) => {
     const currentSemantics = parseCurrentSemantics();
     const updatedSemantics = {
@@ -302,7 +322,22 @@ export default function Semantics({ isActive }: SemanticsProps) {
     };
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
     setRelationReificationTypes(relationReificationTypes);
-  }
+  };
+
+  const handleRelationReificationTranslationRuleChange = (
+    relationName: string,
+    rule: RelationReificationTranslationRules
+  ) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      relationReificationTranslationRules: {
+        ...currentSemantics.relationReificationTranslationRules,
+        [relationName]: rule,
+      },
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+  };
 
   // Attributes
   const handleAttributeTypesChange = (attributes: string[]) => {
@@ -498,6 +533,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
               relationTranslationRules={parseCurrentSemantics().relationTranslationRules}
               relationPropertySchema={parseCurrentSemantics().relationPropertySchema}
               relationReificationTypes={relationReificationTypes}
+              relationReificationTranslationRules={parseCurrentSemantics().relationReificationTranslationRules}
               attributeTypes={attributeTypes}
               attributeTranslationRules={parseCurrentSemantics().attributeTranslationRules}
               hierarchyTypes={hierarchyTypes}
@@ -508,6 +544,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
               onRelationTranslationRuleChange={handleRelationTranslationRuleChange}
               onRelationPropertySchemaChange={handleRelationPropertySchemaChange}
               onRelationReificationTypesChange={handleRelationReificationTypes}
+              onRelationReificationTranslationRuleChange={handleRelationReificationTranslationRuleChange}
               onAttributeTypesChange={handleAttributeTypesChange}
               onAttributeTranslationRuleChange={handleAttributeTranslationRuleChange}
               onHierarchyTypesChange={handleHierarchyChange}

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -7,6 +7,8 @@ import { SelectOptionProps } from '../../InfiniteSelect/index.types';
 import { getServiceUrl } from '../../LanguageManager/index.utils';
 import SourceCode from '../TextualMode/SourceCode/SourceCode';
 import { formatCode } from '../index.utils';
+import VisualSemanticEditor from './VisualSemanticEditor';
+import { Dropdown, DropdownButton } from 'react-bootstrap';
 
 const LIMIT = 20;
 
@@ -30,6 +32,13 @@ export default function Sematics() {
   );
   const [isFetchingSemantics, setIsFetchingSemantics] = useState(true);
   const [totalItems, setTotalItems] = useState(0);
+
+  const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
+
+  // Manejar el cambio de modo de vista
+  const handleSwitchToForm = () => setViewMode('form');
+  const handleSwitchToJson = () => setViewMode('json');
+
 
   const handleSelect = (option: SelectOptionProps) => {
     const selectedSemantics =
@@ -142,7 +151,20 @@ export default function Sematics() {
         searchInput={searchInput}
         setSearchInput={onSearchChange}
       />
-      <SourceCode code={semantics} dispatcher={setSemantics} />
+
+      {/* DropDown button para elegir entre el formulario o el modo textual */}
+      <div>
+        <DropdownButton size="sm" title="Mode" variant="primary" id="modeDropdown" className="mb-3">
+          <Dropdown.Item onClick={handleSwitchToForm}>Visual Editor</Dropdown.Item>
+          <Dropdown.Item onClick={handleSwitchToJson}>Textual editor</Dropdown.Item>
+        </DropdownButton>
+
+        {viewMode === "form" ? (
+          <VisualSemanticEditor />
+        ) : (
+          <SourceCode code={semantics} dispatcher={setSemantics} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -37,6 +37,22 @@ interface AttributeTranslationRule {
   constraint: string;
 }
 
+interface HierarchyTranslationRule {
+  nodeRule?: {
+      param: string[];
+      paramMapping: {
+          incoming: boolean;
+          var: string;
+          node: string;
+      };
+      constraint: string;
+  };
+  leafRule?: {
+      param: string;
+      constraint: string;
+  };
+}
+
 interface SemanticsProps {
   isActive: boolean;
 }
@@ -52,6 +68,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
   const [relationTypes, setRelationTypes] = useState<string[]>([]);
   const [attributeTypes, setAttributeTypes] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
+  const [hierarchyTypes, setHierarchyTypes] = useState<string[]>([]);
 
   const [state, setState] = useState<SemanticsState>({
     isLoading: true,
@@ -95,7 +112,9 @@ export default function Semantics({ isActive }: SemanticsProps) {
         parsed.hasOwnProperty('relationTypes') &&
         Array.isArray(parsed.relationTypes) &&
         parsed.hasOwnProperty('relationTranslationRules') &&
-        Array.isArray(parsed.relationTranslationRules)
+        Array.isArray(parsed.relationTranslationRules) &&
+        parsed.hasOwnProperty('hierarchyTypes') &&
+        Array.isArray(parsed.hierarchyTypes)
       );
     } catch (e) {
       return false;
@@ -191,7 +210,9 @@ export default function Semantics({ isActive }: SemanticsProps) {
         relationTranslationRules: parsedSemantics.relationTranslationRules || {},
         attributeTypes: parsedSemantics.attributeTypes || [],
         attributeTranslationRules: parsedSemantics.attributeTranslationRules || {},
-        // Añadir otros campos según sea necesario (Los siguientes puede hierarchyTypes, typingRelationTypes, etc.)
+        hierarchyTypes: parsedSemantics.hierarchyTypes || [],
+        hierarchyTranslationRules: parsedSemantics.hierarchyTranslationRules || {},
+        // Añadir otros campos según sea necesario (Los siguientes pueden ser typingRelationTypes, etc.)
       };
     } catch (e) {
       console.error('Error parsing semantics:', e);
@@ -202,6 +223,8 @@ export default function Semantics({ isActive }: SemanticsProps) {
         relationTranslationRules: {},
         attributeTypes: [],
         attributeTranslationRules: {},
+        hierarchyTypes: [],
+        hierarchyTranslationRules: {},
       };
     }
   }, [semantics]);
@@ -214,6 +237,8 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setRelationTypes(relationTypes);
     const { attributeTypes } = parseCurrentSemantics();
     setAttributeTypes(attributeTypes);
+    const { hierarchyTypes } = parseCurrentSemantics();
+    setHierarchyTypes(hierarchyTypes);
   }, [semantics, parseCurrentSemantics]);
 
   // Manejar el cambio de elementos seleccionados
@@ -285,6 +310,32 @@ export default function Semantics({ isActive }: SemanticsProps) {
       attributeTranslationRules: {
         ...currentSemantics.attributeTranslationRules,
         [attributeName]: rule,
+      },
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+  };
+
+  // Hierarchy
+  const handleHierarchyChange = (hierarchy: string[]) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      hierarchyTypes: hierarchy,
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+    setHierarchyTypes(hierarchy);
+  };
+
+  const handleHierarchyTranslationRuleChange = (
+    hierarchyName: string, 
+    rule: HierarchyTranslationRule
+  ) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      hierarchyTranslationRules: {
+        ...currentSemantics.hierarchyTranslationRules,
+        [hierarchyName]: rule,
       },
     };
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
@@ -431,12 +482,16 @@ export default function Semantics({ isActive }: SemanticsProps) {
               relationTranslationRules={parseCurrentSemantics().relationTranslationRules}
               attributeTypes={attributeTypes}
               attributeTranslationRules={parseCurrentSemantics().attributeTranslationRules}
+              hierarchyTypes={hierarchyTypes}
+              hierarchyTranslationRules={parseCurrentSemantics().hierarchyTranslationRules}
               onElementsChange={handleElementsChange}
               onTranslationRuleChange={handleTranslationRuleChange}
               onRelationsChange={handleRelationsChange}
               onRelationTranslationRuleChange={handleRelationTranslationRuleChange}
               onAttributeTypesChange={handleAttributeTypesChange}
               onAttributeTranslationRuleChange={handleAttributeTranslationRuleChange}
+              onHierarchyTypesChange={handleHierarchyChange}
+              onHierarchyTranslationRuleChange={handleHierarchyTranslationRuleChange}
             />
           ) : (
             <SourceCode code={semantics} dispatcher={setSemantics} />

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -28,6 +28,7 @@ interface TranslationRule {
 export default function Sematics() {
   const { semantics, setSemantics, elements, relationships } = useLanguageContext();
   const [selectedElements, setSelectedElements] = useState<string[]>([]);
+  const [relationTypes, setRelationTypes] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
 
   const [state, setState] = useState<SemanticsState>({
@@ -134,7 +135,8 @@ export default function Sematics() {
       return {
         elementTypes: parsedSemantics.elementTypes || [],
         elementTranslationRules: parsedSemantics.elementTranslationRules || {},
-        // Añadir otros campos según sea necesario (Siguiente el relationTypes)
+        relationTypes: parsedSemantics.relationTypes || [],
+        // Añadir otros campos según sea necesario (Siguiente el relationTranslationRules)
       };
     } catch (e) {
       console.error('Error parsing semantics:', e);
@@ -149,6 +151,8 @@ export default function Sematics() {
   useEffect(() => {
     const { elementTypes } = parseCurrentSemantics();
     setSelectedElements(elementTypes);
+    const { relationTypes } = parseCurrentSemantics();
+    setRelationTypes(relationTypes);
   }, [semantics, parseCurrentSemantics]);
 
   // Manejar el cambio de elementos seleccionados
@@ -161,6 +165,17 @@ export default function Sematics() {
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
     setSelectedElements(elements);
   };
+
+  // Manejar el cambio de relationTypes
+  const handleRelationsChange = (relations: string[]) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+        ...currentSemantics,
+        relationTypes: relations,
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+    setRelationTypes(relations);
+};
 
   const handleTranslationRuleChange = (elementName: string, rule: TranslationRule) => {
     const currentSemantics = parseCurrentSemantics();
@@ -311,8 +326,10 @@ export default function Sematics() {
               elements={elements}
               selectedElements={selectedElements}
               elementTranslationRules={parseCurrentSemantics().elementTranslationRules}
+              relationTypes={relationTypes}
               onElementsChange={handleElementsChange}
               onTranslationRuleChange={handleTranslationRuleChange}
+              onRelationsChange={handleRelationsChange}
             />
           ) : (
             <SourceCode code={semantics} dispatcher={setSemantics} />

--- a/src/core/components/LanguageDetail/Semantics/index.tsx
+++ b/src/core/components/LanguageDetail/Semantics/index.tsx
@@ -30,6 +30,13 @@ interface RelationTranslationRule {
   constraint: string;
 }
 
+interface AttributeTranslationRule {
+  parent: string;
+  param: string;
+  template: string;
+  constraint: string;
+}
+
 interface SemanticsProps {
   isActive: boolean;
 }
@@ -43,6 +50,7 @@ export default function Semantics({ isActive }: SemanticsProps) {
   } = useLanguageContext();
   const [selectedElements, setSelectedElements] = useState<string[]>([]);
   const [relationTypes, setRelationTypes] = useState<string[]>([]);
+  const [attributeTypes, setAttributeTypes] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
 
   const [state, setState] = useState<SemanticsState>({
@@ -181,7 +189,9 @@ export default function Semantics({ isActive }: SemanticsProps) {
         elementTranslationRules: parsedSemantics.elementTranslationRules || {},
         relationTypes: parsedSemantics.relationTypes || [],
         relationTranslationRules: parsedSemantics.relationTranslationRules || {},
-        // Añadir otros campos según sea necesario (Los siguientes puede ser attributeTypes y attributeTranslationRules)
+        attributeTypes: parsedSemantics.attributeTypes || [],
+        attributeTranslationRules: parsedSemantics.attributeTranslationRules || {},
+        // Añadir otros campos según sea necesario (Los siguientes puede hierarchyTypes, typingRelationTypes, etc.)
       };
     } catch (e) {
       console.error('Error parsing semantics:', e);
@@ -190,6 +200,8 @@ export default function Semantics({ isActive }: SemanticsProps) {
         elementTranslationRules: {},
         relationTypes: [],
         relationTranslationRules: {},
+        attributeTypes: [],
+        attributeTranslationRules: {},
       };
     }
   }, [semantics]);
@@ -200,6 +212,8 @@ export default function Semantics({ isActive }: SemanticsProps) {
     setSelectedElements(elementTypes);
     const { relationTypes } = parseCurrentSemantics();
     setRelationTypes(relationTypes);
+    const { attributeTypes } = parseCurrentSemantics();
+    setAttributeTypes(attributeTypes);
   }, [semantics, parseCurrentSemantics]);
 
   // Manejar el cambio de elementos seleccionados
@@ -246,6 +260,31 @@ export default function Semantics({ isActive }: SemanticsProps) {
       relationTranslationRules: {
         ...currentSemantics.relationTranslationRules,
         [relationName]: rule,
+      },
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+  };
+
+  const handleAttributeTypesChange = (attributes: string[]) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      attributeTypes: attributes,
+    };
+    setSemantics(JSON.stringify(updatedSemantics, null, 2));
+    setAttributeTypes(attributes);
+  };
+
+  const handleAttributeTranslationRuleChange = (
+    attributeName: string,
+    rule: AttributeTranslationRule
+  ) => {
+    const currentSemantics = parseCurrentSemantics();
+    const updatedSemantics = {
+      ...currentSemantics,
+      attributeTranslationRules: {
+        ...currentSemantics.attributeTranslationRules,
+        [attributeName]: rule,
       },
     };
     setSemantics(JSON.stringify(updatedSemantics, null, 2));
@@ -390,10 +429,14 @@ export default function Semantics({ isActive }: SemanticsProps) {
               elementTranslationRules={parseCurrentSemantics().elementTranslationRules}
               relationTypes={relationTypes}
               relationTranslationRules={parseCurrentSemantics().relationTranslationRules}
+              attributeTypes={attributeTypes}
+              attributeTranslationRules={parseCurrentSemantics().attributeTranslationRules}
               onElementsChange={handleElementsChange}
               onTranslationRuleChange={handleTranslationRuleChange}
               onRelationsChange={handleRelationsChange}
               onRelationTranslationRuleChange={handleRelationTranslationRuleChange}
+              onAttributeTypesChange={handleAttributeTypesChange}
+              onAttributeTranslationRuleChange={handleAttributeTranslationRuleChange}
             />
           ) : (
             <SourceCode code={semantics} dispatcher={setSemantics} />

--- a/src/core/components/LanguageDetail/index.tsx
+++ b/src/core/components/LanguageDetail/index.tsx
@@ -62,6 +62,8 @@ export default function LanguageDetail({
   const { setCreatingMode } = useLanguageContext();
   const [confirmModalState, setConfirmModalState] = useState<ConfirmationModalProps>({...confirmationModalDefaultProps});
 
+  const [activeTab, setActiveTab] = useState('information');
+
   const {
     abstractSyntax,
     setAbstractSyntax,
@@ -302,7 +304,12 @@ export default function LanguageDetail({
           )}
         </Row>
       </Container>
-      <Tabs defaultActiveKey="information" id="uncontrolled-tab">
+      <Tabs 
+        defaultActiveKey="information" 
+        id="uncontrolled-tab" 
+        activeKey={activeTab} 
+        onSelect={(key) => setActiveTab(key || 'information')}
+      >
         <Tab eventKey="information" title="Information">
           <InputGroup className="mb-3 mt-3">
             <InputGroup.Text id="inputGroup-sizing-default">Name</InputGroup.Text>
@@ -343,7 +350,7 @@ export default function LanguageDetail({
           {creatingMode === config.modeGraphicalLabel && <GraphicalMode />}
         </Tab>
         <Tab eventKey="semantics" title="Semantics" id="uncontrolled-tab" className="my-3">
-          <Semantics />
+          <Semantics isActive={activeTab === 'semantics'} />
         </Tab>
         <Tab eventKey="comments" title="Comments">
           {/* Add Comment */}


### PR DESCRIPTION
Implements a graphical mode to allow users to edit the semantics of a modeling language.

- Added a graphical form to the `VisualSemanticEditor` component.
- Implemented a dropdown to toggle between the graphical form and textual JSON mode.
- Integrated real-time synchronization between the graphical form and the textual mode to keep both representations consistent.