### PR TITLE
feat: Canvas workSpace and drawing boundaries implementation

### DIFF
--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
@@ -66,13 +66,16 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
   useEffect(() => {    
     const canvas = canvasRef.current;
     if (canvas) {
-      const context = canvas.getContext('2d');
-      if (context) {
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        context.fillStyle = '#ffffff';
-        context.fillRect(0, 0, canvas.width, canvas.height);
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-        drawShapes(context);
+        // Dibujar las lineas guia
+        drawGuideLines(ctx);
+
+        drawShapes(ctx);
       }
 
       if (selectedTool === 'rectangle' || 
@@ -89,6 +92,30 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
       }
     }
   }, [shapeCollection, selectedTool, selectedShape]);
+
+  // Dibujar las lineas guia
+  const drawGuideLines = (ctx: CanvasRenderingContext2D) => {
+    ctx.save();
+    ctx.strokeStyle = '#d3d3d3';
+    ctx.lineWidth = 1;
+
+    ctx.beginPath();
+    ctx.moveTo(0, 100);
+    ctx.lineTo(400, 100);
+
+    ctx.moveTo(0, 300);
+    ctx.lineTo(400, 300);
+
+    // Líneas verticales
+    ctx.moveTo(100, 0);
+    ctx.lineTo(100, 400);
+
+    ctx.moveTo(300, 0);
+    ctx.lineTo(300, 400);
+
+    ctx.stroke();
+    ctx.restore();
+  }
 
   const handleSelectTool = (tool: string) => {
     setSelectedTool(tool);
@@ -208,11 +235,13 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
       if (selectedShape instanceof Polygon) {
         ShapeUtils.resizePolygon(selectedShape as Polygon, resizeHandleIndex, currentX, currentY);
         context.clearRect(0, 0, canvas.width, canvas.height);
+        drawGuideLines(context);
         drawShapes(context);
       } else{
         ShapeUtils.resizeShape(selectedShape, resizeHandleIndex, currentX, currentY);
         console.log(selectedShape, resizeHandleIndex, currentX, currentY);
         context.clearRect(0, 0, canvas.width, canvas.height);
+        drawGuideLines(context);
         drawShapes(context);
       }
       return;
@@ -220,6 +249,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
 
     if (isDrawing && startX !== null && startY !== null) {
       context.clearRect(0, 0, canvas.width, canvas.height);
+      drawGuideLines(context);
       drawShapes(context);
   
       let shape: Shape;
@@ -259,11 +289,13 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
       setStartY(currentY);
   
       context.clearRect(0, 0, canvas.width, canvas.height);
+      drawGuideLines(context);
       drawShapes(context);
     }
 
     if (selectedTool === 'polygon' && currentPolygon) {
       context.clearRect(0, 0, canvas.width, canvas.height);
+      drawGuideLines(context);
       drawShapes(context);
   
       currentPolygon.draw(context);
@@ -404,6 +436,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         const context = canvas.getContext('2d');
         if (context) {
           context.clearRect(0, 0, canvas.width, canvas.height);
+          drawGuideLines(context);
           drawShapes(context);
         }
       }
@@ -419,6 +452,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         const context = canvas.getContext('2d');
         if (context) {
           context.clearRect(0, 0, canvas.width, canvas.height);
+          drawGuideLines(context);
           drawShapes(context);
         }
       }
@@ -434,6 +468,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         const context = canvas.getContext('2d');
         if (context) {
           context.clearRect(0, 0, canvas.width, canvas.height);
+          drawGuideLines(context);
           drawShapes(context);
         }
       }
@@ -449,6 +484,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         const context = canvas.getContext('2d');
         if (context) {
           context.clearRect(0, 0, canvas.width, canvas.height);
+          drawGuideLines(context);
           drawShapes(context);
         }
       }
@@ -464,6 +500,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         const context = canvas.getContext('2d');
         if (context) {
           context.clearRect(0, 0, canvas.width, canvas.height);
+          drawGuideLines(context);
           drawShapes(context);
         }
       }
@@ -479,6 +516,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         const context = canvas.getContext('2d');
         if (context) {
           context.clearRect(0, 0, canvas.width, canvas.height);
+          drawGuideLines(context);
           drawShapes(context);
         }
       }

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
@@ -12,6 +12,7 @@ import { ShapeUtils } from './Shapes/ShapeUtils';
 import { Polygon } from "./Shapes/Polygon";
 import { TextElement } from './Shapes/TextElement';
 import { Modal, Button, Form } from 'react-bootstrap';
+import { set } from 'immer/dist/internal';
 
 interface CanvasProps {
   xml: string;
@@ -237,6 +238,8 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
           updatedShapeCollection.addShape(currentPolygon);
           setShapeCollection(updatedShapeCollection);
           setCurrentPolygon(null); // Terminar el dibujo
+          setSelectedTool('select');
+          setSelectedShape(currentPolygon);
         }
       }
     } else if (selectedTool === 'text') {
@@ -395,7 +398,8 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
 
         // Actualizar el estado con la misma instancia
         setShapeCollection(updatedShapeCollection);
-        setSelectedShape(null);
+        setSelectedTool('select');
+        setSelectedShape(newShape);
       }
     }
 

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
@@ -12,7 +12,6 @@ import { ShapeUtils } from './Shapes/ShapeUtils';
 import { Polygon } from "./Shapes/Polygon";
 import { TextElement } from './Shapes/TextElement';
 import { Modal, Button, Form } from 'react-bootstrap';
-import { set } from 'immer/dist/internal';
 
 interface CanvasProps {
   xml: string;
@@ -74,12 +73,10 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
       const ctx = canvas.getContext('2d');
       if (ctx) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.fillStyle = '#ffffff';
+        ctx.fillStyle = '#d3d3d3';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-        // Dibujar las lineas guia
-        drawGuideLines(ctx);
-
+        drawWorkSpace(ctx);
         drawShapes(ctx);
       }
 
@@ -99,27 +96,13 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
     }
   }, [shapeCollection, selectedTool, selectedShape]);
 
-  // Dibujar las lineas guia
-  const drawGuideLines = (ctx: CanvasRenderingContext2D) => {
+  const drawWorkSpace = (ctx: CanvasRenderingContext2D) => {
     ctx.save();
-    ctx.strokeStyle = '#d3d3d3';
+    ctx.fillStyle = '#ffffff';
     ctx.lineWidth = 1;
 
-    ctx.beginPath();
-    ctx.moveTo(0, 100);
-    ctx.lineTo(400, 100);
+    ctx.fillRect(100, 100, 300, 300);
 
-    ctx.moveTo(0, 300);
-    ctx.lineTo(400, 300);
-
-    // Líneas verticales
-    ctx.moveTo(100, 0);
-    ctx.lineTo(100, 400);
-
-    ctx.moveTo(300, 0);
-    ctx.lineTo(300, 400);
-
-    ctx.stroke();
     ctx.restore();
   }
   
@@ -132,7 +115,12 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
     if (!ctx) return;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    drawGuideLines(ctx);
+
+    // Establece el color de fondo
+    ctx.fillStyle = '#d3d3d3';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    
+    drawWorkSpace(ctx);
     drawShapes(ctx);
   };
 
@@ -595,8 +583,8 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
         <div className="d-flex justify-content-center">
           <canvas
             ref={canvasRef}
-            width={400}
-            height={400}
+            width={500}
+            height={500}
             style={{ border: '1px solid #000' }}
             onMouseDown={handleMouseDown}
             onMouseMove={handleMouseMove}
@@ -636,7 +624,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
             Save
           </Button>
         </Modal.Footer>
-      </Modal>
+        </Modal>
       </div>
     </div>
   );  

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Canvas.tsx
@@ -116,6 +116,19 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
     ctx.stroke();
     ctx.restore();
   }
+  
+  // Resetear el canvas
+  const resetCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+  
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawGuideLines(ctx);
+    drawShapes(ctx);
+  };
 
   const handleSelectTool = (tool: string) => {
     setSelectedTool(tool);
@@ -234,23 +247,17 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
      if (isResizing && selectedShape && resizeHandleIndex !== null) {
       if (selectedShape instanceof Polygon) {
         ShapeUtils.resizePolygon(selectedShape as Polygon, resizeHandleIndex, currentX, currentY);
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        drawGuideLines(context);
-        drawShapes(context);
+        resetCanvas();
       } else{
         ShapeUtils.resizeShape(selectedShape, resizeHandleIndex, currentX, currentY);
         console.log(selectedShape, resizeHandleIndex, currentX, currentY);
-        context.clearRect(0, 0, canvas.width, canvas.height);
-        drawGuideLines(context);
-        drawShapes(context);
+        resetCanvas();
       }
       return;
     }
 
     if (isDrawing && startX !== null && startY !== null) {
-      context.clearRect(0, 0, canvas.width, canvas.height);
-      drawGuideLines(context);
-      drawShapes(context);
+      resetCanvas();
   
       let shape: Shape;
   
@@ -288,15 +295,11 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
       setStartX(currentX);
       setStartY(currentY);
   
-      context.clearRect(0, 0, canvas.width, canvas.height);
-      drawGuideLines(context);
-      drawShapes(context);
+      resetCanvas();
     }
 
     if (selectedTool === 'polygon' && currentPolygon) {
-      context.clearRect(0, 0, canvas.width, canvas.height);
-      drawGuideLines(context);
-      drawShapes(context);
+      resetCanvas();
   
       currentPolygon.draw(context);
   
@@ -435,9 +438,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
       if (canvas) {
         const context = canvas.getContext('2d');
         if (context) {
-          context.clearRect(0, 0, canvas.width, canvas.height);
-          drawGuideLines(context);
-          drawShapes(context);
+          resetCanvas();
         }
       }
       updateXml();
@@ -447,15 +448,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
     if (selectedShape) {
       selectedShape.setFillColor(color);
 
-      const canvas = canvasRef.current;
-      if (canvas) {
-        const context = canvas.getContext('2d');
-        if (context) {
-          context.clearRect(0, 0, canvas.width, canvas.height);
-          drawGuideLines(context);
-          drawShapes(context);
-        }
-      }
+      resetCanvas();
     }
     updateXml();
   };
@@ -463,15 +456,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
   const handleLineColorChange = (color: string) => {
     if (selectedShape) {
       selectedShape.setLineColor(color);
-      const canvas = canvasRef.current;
-      if (canvas) {
-        const context = canvas.getContext('2d');
-        if (context) {
-          context.clearRect(0, 0, canvas.width, canvas.height);
-          drawGuideLines(context);
-          drawShapes(context);
-        }
-      }
+      resetCanvas();
     }
     updateXml();
   };
@@ -479,15 +464,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
   const handleLineStyleChange = (style: string | number[]) => {
     if (selectedShape) {
       selectedShape.setLineStyle(style);
-      const canvas = canvasRef.current;
-      if (canvas) {
-        const context = canvas.getContext('2d');
-        if (context) {
-          context.clearRect(0, 0, canvas.width, canvas.height);
-          drawGuideLines(context);
-          drawShapes(context);
-        }
-      }
+      resetCanvas();
     }
     updateXml();
   };
@@ -495,15 +472,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
   const handleLineWidthChange = (width: number) => {
     if (selectedShape) {
       selectedShape.setLineWidth(width);
-      const canvas = canvasRef.current;
-      if (canvas) {
-        const context = canvas.getContext('2d');
-        if (context) {
-          context.clearRect(0, 0, canvas.width, canvas.height);
-          drawGuideLines(context);
-          drawShapes(context);
-        }
-      }
+      resetCanvas();
     }
     updateXml();
   }
@@ -511,15 +480,7 @@ export default function Canvas({xml, onXmlChange, scaleFactor, onScaleFactorChan
   const handleFontSizeChange = (size: number) => {
     if (selectedShape instanceof TextElement) {
       selectedShape.fontSize = size;
-      const canvas = canvasRef.current;
-      if (canvas) {
-        const context = canvas.getContext('2d');
-        if (context) {
-          context.clearRect(0, 0, canvas.width, canvas.height);
-          drawGuideLines(context);
-          drawShapes(context);
-        }
-      }
+      resetCanvas();
     }
     updateXml();
   }

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/BezierCurve.ts
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/BezierCurve.ts
@@ -1,0 +1,126 @@
+import { Shape } from './Shape';
+
+export class BezierCurve extends Shape {
+    public x2: number;
+    public y2: number;
+    public controlPoint1: { x: number; y: number };
+    public controlPoint2: { x: number; y: number };
+    
+    constructor(
+        x: number, 
+        y: number, 
+        x2: number, 
+        y2: number, 
+        lineColor: string = '#000000',
+        controlPoint1?: { x: number; y: number },
+        controlPoint2?: { x: number; y: number }
+    ) {
+        super(x, y, undefined, undefined, undefined, lineColor);
+        this.x2 = x2;
+        this.y2 = y2;
+        // Inicializar puntos de control en la línea
+        if (controlPoint1 && controlPoint2) {
+            this.controlPoint1 = controlPoint1;
+            this.controlPoint2 = controlPoint2;
+        } else {
+            this.controlPoint1 = { x: (x + x2) / 3, y: (y + y2) / 3 };
+            this.controlPoint2 = { x: (x + x2) * 2 / 3, y: (y + y2) * 2 / 3 };
+        }
+    }
+
+    protected drawShape(ctx: CanvasRenderingContext2D): void {
+        ctx.save();  // Guardar el contexto actual
+        ctx.beginPath();
+        ctx.moveTo(this.x, this.y);
+
+        ctx.bezierCurveTo(
+        this.controlPoint1.x, this.controlPoint1.y,
+        this.controlPoint2.x, this.controlPoint2.y,
+        this.x2, this.y2
+        );
+    
+        // Aplicar color de línea y estilo
+        ctx.strokeStyle = this.lineColor;
+        ctx.setLineDash(this.lineStyle);  // Aplicar estilo de línea
+        ctx.lineWidth = this.lineWidth;
+        ctx.stroke();
+    
+        ctx.restore();  // Restaurar el contexto original
+    }
+
+    drawCurveHandles(ctx: CanvasRenderingContext2D): void {
+        const controlPoints = this.getControlPoints();
+      
+        controlPoints.forEach(handle => {
+          ctx.fillStyle = '#00BFFF';
+          ctx.fillRect(handle.x - 5, handle.y - 5, 10, 10);
+        });
+    }
+
+    contains(x: number, y: number): boolean {
+        const threshold = 5;
+        const steps = 100;
+        for (let i = 1; i <= steps; i++) {
+            const t = i / steps;
+            const xt = Math.pow(1 - t, 3) * this.x +
+                        3 * Math.pow(1 - t, 2) * t * this.controlPoint1.x +
+                        3 * (1 - t) * Math.pow(t, 2) * this.controlPoint2.x +
+                        Math.pow(t, 3) * this.x2;
+            const yt = Math.pow(1 - t, 3) * this.y +
+                        3 * Math.pow(1 - t, 2) * t * this.controlPoint1.y +
+                        3 * (1 - t) * Math.pow(t, 2) * this.controlPoint2.y +
+                        Math.pow(t, 3) * this.y2;
+
+            const dx = xt - x;
+            const dy = yt - y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+
+            if (distance < threshold) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Sobreescribir el método para obtener "handles" específicos de una línea
+    getResizeHandles(): { x: number, y: number }[] {
+        return [
+        { x: this.x, y: this.y },
+        { x: this.x2, y: this.y2 },
+        ];
+    }
+
+    getControlPoints(): { x: number; y: number }[] {
+        return [this.controlPoint1, this.controlPoint2];
+    }
+
+    getType(): string {
+        return 'curve';
+    }
+
+    // Sobreescribir el método para verificar si el mouse está sobre un "handle" de la línea
+    isOverHandle(mouseX: number, mouseY: number): boolean {
+        const handles = this.getResizeHandles();
+        return handles.some(handle =>
+        Math.abs(mouseX - handle.x) <= 5 && Math.abs(mouseY - handle.y) <= 5
+        );
+    }
+
+    isOverControlPoint(mouseX: number, mouseY: number): boolean {
+        const controlPoints = this.getControlPoints();
+        return controlPoints.some(point =>
+        Math.abs(mouseX - point.x) <= 5 && Math.abs(mouseY - point.y) <= 5
+        );
+    };
+
+    translateControlPoint(controlPointIndex: number, newX: number, newY: number): void {
+        if (controlPointIndex === 0) {
+            this.controlPoint1.x = newX;
+            this.controlPoint1.y = newY;
+        } else if (controlPointIndex === 1) {
+            this.controlPoint2.x = newX;
+            this.controlPoint2.y = newY;
+        }
+    }
+}

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/ShapeCollection.ts
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/ShapeCollection.ts
@@ -85,57 +85,12 @@ export class ShapeCollection {
     }
 
     toXML(): string {
-        // Inicializamos las variables para encontrar el bounding box de todas las figuras
-        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-        let textElements: TextElement[] = [];
-    
-        // Primero, recorremos todas las figuras para calcular el bounding box global y guardamos las etiquetas de texto en una lista
-        this.shapes.forEach(shape => {
-            switch (shape.getType()) {
-                case 'rectangle':
-                case 'ellipse':
-                    minX = Math.min(minX, shape.x);
-                    minY = Math.min(minY, shape.y);
-                    maxX = Math.max(maxX, shape.x + shape.width);
-                    maxY = Math.max(maxY, shape.y + shape.height);
-                    break;
-                case 'line':
-                    const line = shape as Line;
-                    minX = Math.min(minX, line.x, line.x2);
-                    minY = Math.min(minY, line.y, line.y2);
-                    maxX = Math.max(maxX, line.x, line.x2);
-                    maxY = Math.max(maxY, line.y, line.y2);
-                    break;
-                case 'triangle':
-                    const triangle = shape as Triangle;
-                    minX = Math.min(minX, triangle.x, triangle.x + triangle.width / 2, triangle.x + triangle.width);
-                    minY = Math.min(minY, triangle.y, triangle.y + triangle.height);
-                    maxX = Math.max(maxX, triangle.x, triangle.x + triangle.width / 2, triangle.x + triangle.width);
-                    maxY = Math.max(maxY, triangle.y, triangle.y + triangle.height);
-                    break;
-                case 'polygon':
-                    const polygon = shape as Polygon;
-                    polygon.points.forEach(point => {
-                        minX = Math.min(minX, point.x);
-                        minY = Math.min(minY, point.y);
-                        maxX = Math.max(maxX, point.x);
-                        maxY = Math.max(maxY, point.y);
-                    });
-                    break;
-                case 'text':
-                    textElements.push(shape as TextElement);
-                    break;
-            }
-        });
-    
-        // Calculamos el tamaño del bounding box
-        const boundingBoxWidth = maxX - minX;
-        const boundingBoxHeight = maxY - minY;
-    
-        // Factor de escala para ajustar las figuras dentro del cuadro de 100x100
-        const scale = 100 / Math.max(boundingBoxWidth, boundingBoxHeight);
+        // Inicializamos la variable de escalado y el desplazamiento y los textos
+        const scale = 1/2;
         this.scale = scale;
-    
+        const offset = 100;
+        let textElements: TextElement[] = [];
+
         // Preparar los atributos
         if (!this.shapeAttributes["name"]) this.shapeAttributes["name"] = "compositeShape";
         if (!this.shapeAttributes["aspect"]) this.shapeAttributes["aspect"] = "variable";
@@ -146,7 +101,7 @@ export class ShapeCollection {
             shapeAttrString += ` ${key}="${value}"`;
         }
 
-        // Generamos el XML escalando las coordenadas
+        // Generamos el XML escalando las coordenadas y ajustando el desplazamiento
         let xml = 
         `<shape ${shapeAttrString}>\n ${this.connectionsXML}\n  <background>\n`;
     
@@ -166,7 +121,7 @@ export class ShapeCollection {
             <strokewidth width="${lineWidth}"/>
             <dashed dashed="${dashed}"/>
             ${dashed ? `<dashpattern pattern="${dashpattern}"/>` : ""}
-            <rect x="${(shape.x - minX) * scale}" y="${(shape.y - minY) * scale}" w="${shape.width * scale}" h="${shape.height * scale}" />
+            <rect x="${(shape.x - offset) * scale}" y="${(shape.y - offset) * scale}" w="${shape.width * scale}" h="${shape.height * scale}" />
             <fillstroke/>\n`;
                     break;
                 case 'ellipse':
@@ -176,7 +131,7 @@ export class ShapeCollection {
             <strokewidth width="${lineWidth}"/>
             <dashed dashed="${dashed}"/>
             ${dashed ? `<dashpattern pattern="${dashpattern}"/>` : ""}
-            <ellipse x="${(shape.x - minX) * scale}" y="${(shape.y - minY) * scale}" w="${shape.width * scale}" h="${shape.height * scale}" />
+            <ellipse x="${(shape.x - offset) * scale}" y="${(shape.y - offset) * scale}" w="${shape.width * scale}" h="${shape.height * scale}" />
             <fillstroke/>\n`;
                     break;
                 case 'line':
@@ -187,19 +142,19 @@ export class ShapeCollection {
             <dashed dashed="${dashed}"/>
             ${dashed ? `<dashpattern pattern="${dashpattern}"/>` : ""}
             <path>
-                <move x="${(line.x - minX) * scale}" y="${(line.y - minY) * scale}"/>
-                <line x="${(line.x2 - minX) * scale}" y="${(line.y2 - minY) * scale}"/>
+                <move x="${(line.x - offset) * scale}" y="${(line.y - offset) * scale}"/>
+                <line x="${(line.x2 - offset) * scale}" y="${(line.y2 - offset) * scale}"/>
             </path>
             <stroke/>\n`;
                     break;
                 case 'triangle':
                     const triangle = shape as Triangle;
-                    const x1 = (triangle.x - minX) * scale;
-                    const y1 = (triangle.y + triangle.height - minY) * scale;
-                    const x2 = (triangle.x + triangle.width / 2 - minX) * scale;
-                    const y2 = (triangle.y - minY) * scale;
-                    const x3 = (triangle.x + triangle.width - minX) * scale;
-                    const y3 = (triangle.y + triangle.height - minY) * scale;
+                    const x1 = (triangle.x - offset) * scale;
+                    const y1 = (triangle.y + triangle.height - offset) * scale;
+                    const x2 = (triangle.x + triangle.width / 2 - offset) * scale;
+                    const y2 = (triangle.y - offset) * scale;
+                    const x3 = (triangle.x + triangle.width - offset) * scale;
+                    const y3 = (triangle.y + triangle.height - offset) * scale;
     
                     xml += `
             <strokecolor color="${strokeColor}"/>
@@ -226,12 +181,12 @@ export class ShapeCollection {
             <path>\n`;
     
                     // Movemos el lápiz al primer punto del polígono
-                    xml += `            <move x="${(polygon.points[0].x - minX) * scale}" y="${(polygon.points[0].y - minY) * scale}"/>\n`;
+                    xml += `            <move x="${(polygon.points[0].x - offset) * scale}" y="${(polygon.points[0].y - offset) * scale}"/>\n`;
     
                     // Dibujamos las líneas entre los puntos
                     for (let i = 1; i < polygon.points.length; i++) {
                         const point = polygon.points[i];
-                        xml += `            <line x="${(point.x - minX) * scale}" y="${(point.y - minY) * scale}"/>\n`;
+                        xml += `            <line x="${(point.x - offset) * scale}" y="${(point.y - offset) * scale}"/>\n`;
                     }
     
                     if (polygon.isClosed) {
@@ -239,6 +194,9 @@ export class ShapeCollection {
                     }
     
                     xml += `        </path>\n        <fillstroke/>\n`;
+                    break;
+                case 'text':
+                    textElements.push(shape as TextElement);
                     break;
             }
         });
@@ -259,7 +217,7 @@ export class ShapeCollection {
                 <fontsize size="${scaledFontSize}"/>\n`;
             }
             xml += `
-            <text str="${textElement.content}" x="${(textElement.x - minX) * scale}" y="${(textElement.y - minY) * scale}"/>\n
+            <text str="${textElement.content}" x="${(textElement.x - offset) * scale}" y="${(textElement.y - offset - textElement.fontSize) * scale}"/>\n
             `;
         });
         // Añadir las otras etiquetas que no tengan soporte
@@ -373,10 +331,13 @@ export class ShapeCollection {
 
     parsePathElement(pathNode: Element, fillColor: string, strokeColor: string, strokeWidth: number, lineStyle: number[]): void {
         let points = [];
+        const scaleFactor = 2;
+        const offsetX = 100;
+        const offsetY = 100;
 
         for (let child of Array.from(pathNode.children)) {
-            const x = parseFloat(child.getAttribute('x') || "0") * 2 + 50;
-            const y = parseFloat(child.getAttribute('y') || "0") * 2 + 50;
+            const x = parseFloat(child.getAttribute('x') || "0") * scaleFactor + offsetX;
+            const y = parseFloat(child.getAttribute('y') || "0") * scaleFactor + offsetY;
 
             switch (child.tagName) {
                 case 'ellipse':
@@ -417,8 +378,8 @@ export class ShapeCollection {
     // Función para procesar el rectángulo
     createRectangle(shapeNode: Element, fillColor: string, lineColor: string, strokeWidth: number,  lineStyle: number[]): void {
         const scaleFactor = 2;
-        const offsetX = 50;
-        const offsetY = 50;
+        const offsetX = 100;
+        const offsetY = 100;
         
         const x = (parseFloat(shapeNode.getAttribute('x') || "0") * scaleFactor) + offsetX;
         const y = (parseFloat(shapeNode.getAttribute('y') || "0") * scaleFactor) + offsetY;
@@ -434,8 +395,8 @@ export class ShapeCollection {
     // Función para procesar la elipse
     createEllipse(shapeNode: Element, fillColor: string, lineColor: string, strokeWidth: number, lineStyle: number[]): void {
         const scaleFactor = 2;
-        const offsetX = 50;
-        const offsetY = 50;
+        const offsetX = 100;
+        const offsetY = 100;
 
         const x = (parseFloat(shapeNode.getAttribute('x') || "0") * scaleFactor) + offsetX;
         const y = (parseFloat(shapeNode.getAttribute('y') || "0") * scaleFactor) + offsetY;
@@ -450,18 +411,18 @@ export class ShapeCollection {
 
     // Función para crear textos
     createText(textElement: Element, fontSize: number): void {
+        // Escalar y desplazar el texto
+        const scaleFactor = 2;
+        const offsetX = 100;
+        const offsetY = 100;
+
         // Recuperar el contenido del texto y otras propiedades
         const content = textElement.getAttribute('str') || "";
         const fontFamily = textElement.getAttribute('fontfamily') || "Arial";
-        fontSize = fontSize / this.scale;
-
-        // Escalar y desplazar el texto
-        const scaleFactor = 2;
-        const offsetX = 50;
-        const offsetY = 50;
+        fontSize = fontSize * scaleFactor;       
 
         const x = (parseFloat(textElement.getAttribute('x') || "0") * scaleFactor) + offsetX;
-        const y = (parseFloat(textElement.getAttribute('y') || "0") * scaleFactor) + offsetY;
+        const y = (parseFloat(textElement.getAttribute('y') || "0") * scaleFactor) + offsetY + fontSize;
 
         // Crear el elemento de texto
         const text = new TextElement(x, y, content, fontSize, fontFamily);

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/ShapeCollection.ts
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/ShapeCollection.ts
@@ -156,7 +156,7 @@ export class ShapeCollection {
 
     toXML(): string {
         // Inicializamos la variable de escalado y el desplazamiento y los textos
-        const scale = 1/2;
+        const scale = 1/3;
         this.scale = scale;
         const offset = 100;
         let textElements: TextElement[] = [];
@@ -414,7 +414,7 @@ export class ShapeCollection {
 
     parsePathElement(pathNode: Element, fillColor: string, strokeColor: string, strokeWidth: number, lineStyle: number[]): void {
         let points = [];
-        const scaleFactor = 2;
+        const scaleFactor = 3;
         const offsetX = 100;
         const offsetY = 100;
 
@@ -486,7 +486,7 @@ export class ShapeCollection {
     
     // Función para procesar el rectángulo
     createRectangle(shapeNode: Element, fillColor: string, lineColor: string, strokeWidth: number,  lineStyle: number[]): void {
-        const scaleFactor = 2;
+        const scaleFactor = 3;
         const offsetX = 100;
         const offsetY = 100;
         
@@ -503,7 +503,7 @@ export class ShapeCollection {
     
     // Función para procesar la elipse
     createEllipse(shapeNode: Element, fillColor: string, lineColor: string, strokeWidth: number, lineStyle: number[]): void {
-        const scaleFactor = 2;
+        const scaleFactor = 3;
         const offsetX = 100;
         const offsetY = 100;
 
@@ -521,7 +521,7 @@ export class ShapeCollection {
     // Función para crear textos
     createText(textElement: Element, fontSize: number): void {
         // Escalar y desplazar el texto
-        const scaleFactor = 2;
+        const scaleFactor = 3;
         const offsetX = 100;
         const offsetY = 100;
 

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/ShapeUtils.ts
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/Shapes/ShapeUtils.ts
@@ -2,6 +2,7 @@ import { Line } from "./Line";
 import type { Shape } from "./Shape";
 import { Polygon } from "./Polygon"
 import { GeometryUtils } from "../GeometryUtils";
+import { BezierCurve } from "./BezierCurve";
 
 export class ShapeUtils {
   static resizeShape(
@@ -10,7 +11,7 @@ export class ShapeUtils {
     currentX: number,
     currentY: number
   ): void {
-    if (shape instanceof Line) {
+    if (shape instanceof Line || shape instanceof BezierCurve) {
       // Si la figura es una línea, simplemente actualizamos uno de sus puntos extremos.
       if (resizeHandleIndex === 0) {
         shape.x = currentX;
@@ -42,8 +43,6 @@ export class ShapeUtils {
 
   static resizePolygon(polygon: Polygon, handleIndex: number, newX: number, newY: number): void {
     if (handleIndex >= 0 && handleIndex < polygon.points.length) {
-        // Obtener el centro del polígono para calcular los nuevos vértices
-        const centroid = GeometryUtils.calculateCentroid(polygon.points);
         
         // Calcular la diferencia de movimiento
         const deltaX = newX - polygon.points[handleIndex].x;
@@ -71,6 +70,15 @@ export class ShapeUtils {
     if (shape instanceof Line) {
       shape.x += deltaX;
       shape.y += deltaY;
+      shape.x2 += deltaX;
+      shape.y2 += deltaY;
+    } else if (shape instanceof BezierCurve) {
+      shape.x += deltaX;
+      shape.y += deltaY;
+      shape.controlPoint1.x += deltaX;
+      shape.controlPoint1.y += deltaY;
+      shape.controlPoint2.x += deltaX;
+      shape.controlPoint2.y += deltaY;
       shape.x2 += deltaX;
       shape.y2 += deltaY;
     } else {

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/ToolBar.tsx
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/ToolBar.tsx
@@ -2,7 +2,7 @@ import React, {useRef, useState } from 'react';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { MdOutlineRectangle, MdOutlineTextFields } from "react-icons/md";
 import { IoEllipseOutline, IoTriangleOutline, IoColorFill, IoColorPaletteOutline } from "react-icons/io5";
-import { FaMinus } from "react-icons/fa6";
+import { FaMinus, FaBezierCurve } from "react-icons/fa6";
 import { RxBorderWidth } from "react-icons/rx";
 import { PiCursorFill } from "react-icons/pi";
 import { FaTrashAlt } from "react-icons/fa";
@@ -145,6 +145,12 @@ export default function ToolBar({
           onClick={() => handleToolClick('line')}
         >
           <FaMinus />
+        </Button>
+        <Button
+          variant={selectedTool === 'curve' ? 'primary' : 'secondary'}
+          onClick={() => handleToolClick('curve')}
+        >
+          <FaBezierCurve />
         </Button>
         <Button
           variant={selectedTool === 'polygon' ? 'primary' : 'secondary'}

--- a/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/ToolBar.tsx
+++ b/src/core/components/LanguageDetail/GraphicalMode/Elements/Drawtool/ToolBar.tsx
@@ -113,69 +113,70 @@ export default function ToolBar({
   };
 
   return (
-    <div className="mb-3">
-      {/* Primera fila: herramientas de formas */}
-      <ButtonGroup aria-label="Shape tools">
-        <Button
-          variant={selectedTool === 'select' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('select')}
-        >
-          <PiCursorFill />
-        </Button>
-        <Button
-          variant={selectedTool === 'rectangle' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('rectangle')}
-        >
-          <MdOutlineRectangle />
-        </Button>
-        <Button
-          variant={selectedTool === 'ellipse' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('ellipse')}
-        >
-          <IoEllipseOutline />
-        </Button>
-        <Button
-          variant={selectedTool === 'triangle' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('triangle')}
-        >
-          <IoTriangleOutline />
-        </Button>
-        <Button
-          variant={selectedTool === 'line' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('line')}
-        >
-          <FaMinus />
-        </Button>
-        <Button
-          variant={selectedTool === 'curve' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('curve')}
-        >
-          <FaBezierCurve />
-        </Button>
-        <Button
-          variant={selectedTool === 'polygon' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('polygon')}
-        >
-          <TbPolygon />
-        </Button>
-        <Button
-          variant={selectedTool === 'text' ? 'primary' : 'secondary'}
-          onClick={() => handleToolClick('text')}
-        >
-          <MdOutlineTextFields  />
-        </Button>
-        <Button
-          variant={hasSelectedShape ? 'danger' : 'secondary'}
-          onClick={onDelete}
-          disabled={!hasSelectedShape}
-        >
-          <FaTrashAlt />
-        </Button>
-      </ButtonGroup>
-
-      {/* Segunda fila: opciones de edición */}
-      <div className="d-flex mt-3 align-items-center">
-        {/* Botón y picker de color de relleno */}
+    <div className="mb-3 d-flex gap-3">
+      {/* Grupo de herramientas de formas */}
+      <div className="d-flex align-items-center gap-2">
+        <ButtonGroup aria-label="Shape tools">
+          <Button
+            variant={selectedTool === 'select' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('select')}
+          >
+            <PiCursorFill />
+          </Button>
+          <Button
+            variant={selectedTool === 'rectangle' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('rectangle')}
+          >
+            <MdOutlineRectangle />
+          </Button>
+          <Button
+            variant={selectedTool === 'ellipse' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('ellipse')}
+          >
+            <IoEllipseOutline />
+          </Button>
+          <Button
+            variant={selectedTool === 'triangle' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('triangle')}
+          >
+            <IoTriangleOutline />
+          </Button>
+          <Button
+            variant={selectedTool === 'line' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('line')}
+          >
+            <FaMinus />
+          </Button>
+          <Button
+            variant={selectedTool === 'curve' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('curve')}
+          >
+            <FaBezierCurve />
+          </Button>
+          <Button
+            variant={selectedTool === 'polygon' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('polygon')}
+          >
+            <TbPolygon />
+          </Button>
+          <Button
+            variant={selectedTool === 'text' ? 'primary' : 'secondary'}
+            onClick={() => handleToolClick('text')}
+          >
+            <MdOutlineTextFields />
+          </Button>
+          <Button
+            variant={hasSelectedShape ? 'danger' : 'secondary'}
+            onClick={onDelete}
+            disabled={!hasSelectedShape}
+          >
+            <FaTrashAlt />
+          </Button>
+        </ButtonGroup>
+      </div>
+  
+      {/* Grupo de herramientas de cambio de color */}
+      <div className="d-flex align-items-center gap-2">
         <ButtonGroup>
           <Button
             variant={showFillColorPicker ? 'primary' : 'secondary'}
@@ -188,12 +189,11 @@ export default function ToolBar({
               <SketchPicker color={fillColor} onChangeComplete={handleFillColorChange} />
             </div>
           )}
-          {/* Botón y picker de color de borde */}
           <Button
             variant={showLineColorPicker ? 'primary' : 'secondary'}
             onClick={toggleLineColorPicker}
           >
-            <IoColorPaletteOutline  />
+            <IoColorPaletteOutline />
           </Button>
           {showLineColorPicker && (
             <div ref={lineColorPickerRef} style={{ marginTop: '80px', position: 'absolute', zIndex: 1000 }}>
@@ -201,9 +201,12 @@ export default function ToolBar({
             </div>
           )}
         </ButtonGroup>
-
+      </div>
+  
+      {/* Herramientas de línea */}
+      <div className="d-flex align-items-center gap-3">
         {/* Dropdown de estilo de línea */}
-        <div className="ms-3">
+        <div className="d-flex align-items-center">
           <TbBorderStyle2 size={24} />
           <select
             className="form-select d-inline-block ms-2"
@@ -218,18 +221,9 @@ export default function ToolBar({
             <option value="custom">Custom…</option>
           </select>
         </div>
-
-        {/* Modal para mostrar el patrón personalizado */}
-        {showCustomModal && (
-        <CustomPatternModal
-          show={showCustomModal}
-          onSave={handleSaveCustomPattern}
-          onCancel={() => setShowCustomModal(false)}
-          />
-        )}
-
+  
         {/* Stepper Control para el grosor de línea */}
-        <div className="ms-3 d-flex align-items-center">
+        <div className="d-flex align-items-center">
           <RxBorderWidth />
           <input
             type="number"
@@ -239,9 +233,9 @@ export default function ToolBar({
             className="mx-2"
           />
         </div>
-
+  
         {/* Control para el tamaño de fuente */}
-        <div className="ms-3 d-flex align-items-center">
+        <div className="d-flex align-items-center">
           <AiOutlineFontSize />
           <div className="position-relative">
             <input
@@ -249,7 +243,7 @@ export default function ToolBar({
               value={fontSize}
               onChange={(e) => handleFontSizeChange(e)}
               onFocus={() => setShowFontSizeOptions(true)}
-              onBlur={() => setTimeout(() => setShowFontSizeOptions(false), 200)} // Retraso para permitir clic en opciones
+              onBlur={() => setTimeout(() => setShowFontSizeOptions(false), 200)}
               style={{ width: '80px', textAlign: 'center' }}
               className="form-control mx-2"
               placeholder="Font Size"
@@ -269,7 +263,9 @@ export default function ToolBar({
                   <li key={size}>
                     <button
                       className="dropdown-item"
-                      onMouseDown={() => handleFontSizeChange({ target: { value: size.toString() } } as React.ChangeEvent<HTMLInputElement>)}
+                      onMouseDown={() =>
+                        handleFontSizeChange({ target: { value: size.toString() } } as React.ChangeEvent<HTMLInputElement>)
+                      }
                     >
                       {size}
                     </button>
@@ -279,8 +275,8 @@ export default function ToolBar({
             )}
           </div>
         </div>
-
       </div>
     </div>
   );
+  
 }


### PR DESCRIPTION
- Add gray area to delimit a canvas workspace
- Reorganize toolbar layout by grouping tools horizontally based on functionality
- Implement drawing functionality within canvas boundaries
- Support shape drawing inside/outside boundaries with XML translation
- Add shape repositioning function for XML import
- Fix vertical text offset caused by fontSize property